### PR TITLE
added sign byte back to emphemkey for stealth.

### DIFF
--- a/include/bitcoin/blockchain/blockchain.hpp
+++ b/include/bitcoin/blockchain/blockchain.hpp
@@ -72,8 +72,7 @@ BCB_API uint64_t spend_checksum(output_point outpoint);
 
 struct BCB_API stealth_row
 {
-    // No sign byte in public key.
-    hash_digest ephemkey;
+    ec_point ephemkey;
     // No version byte in address.
     short_hash address;
     hash_digest transaction_hash;

--- a/src/database/stealth_database.cpp
+++ b/src/database/stealth_database.cpp
@@ -25,8 +25,8 @@ namespace libbitcoin {
     namespace chain {
 
 // ephemkey is without sign byte and address is without version byte.
-// [ prefix_bitfield:4 ][ ephemkey:32 ][ address:20 ][ tx_id:32 ]
-constexpr size_t row_size = 4 + 32 + 20 + 32;
+// [ prefix_bitfield:4 ][ ephemkey:33 ][ address:20 ][ tx_id:32 ]
+constexpr size_t row_size = 4 + 33 + 20 + 32;
 
 stealth_database::stealth_database(
     const std::string& index_filename, const std::string& rows_filename)
@@ -71,7 +71,7 @@ stealth_list stealth_database::scan(
         // Add row to results.
         auto deserial = make_deserializer_unsafe(record + bitfield_size);
         result.push_back({
-            deserial.read_hash(),
+            deserial.read_data(ec_compressed_size),
             deserial.read_short_hash(),
             deserial.read_hash()
         });
@@ -91,7 +91,7 @@ void stealth_database::store(
     // Write data.
     auto serial = make_serializer(record);
     serial.write_data(prefix.blocks());
-    serial.write_hash(row.ephemkey);
+    serial.write_data(row.ephemkey);
     serial.write_short_hash(row.address);
     serial.write_hash(row.transaction_hash);
     BITCOIN_ASSERT(serial.iterator() ==

--- a/src/db_interface.cpp
+++ b/src/db_interface.cpp
@@ -212,14 +212,12 @@ void db_interface::push_outputs(
     }
 }
 
-hash_digest read_ephemkey(const data_chunk& stealth_data)
+ec_point read_ephemkey(const data_chunk& stealth_data)
 {
     // Read ephemkey
-    hash_digest ephemkey;
-    BITCOIN_ASSERT(stealth_data.size() >= hash_size);
-    std::copy(stealth_data.begin(), stealth_data.begin() + hash_size,
-        ephemkey.begin());
-    return ephemkey;
+    BITCOIN_ASSERT(stealth_data.size() >= ec_compressed_size);
+    return ec_point(stealth_data.begin(),
+        stealth_data.begin() + ec_compressed_size);
 }
 
 void db_interface::push_stealth_outputs(

--- a/tools/stealth_db.cpp
+++ b/tools/stealth_db.cpp
@@ -140,7 +140,7 @@ int main(int argc, char** argv)
         script_type script = unpretty(script_str);
         stealth_row row;
         // ephemkey
-        if (!decode_hash(row.ephemkey, args[1]))
+        if (!decode_base16(row.ephemkey, args[1]))
         {
             std::cerr << "Unable to read ephemeral pubkey." << std::endl;
             return -1;


### PR DESCRIPTION
This increases the number of client side computations, which reduces the
anonymity. It is trivial for the server to store this data and halves
the computation workload for the client, thereby increasing the
acceptable working dataset & improving anonymity for the client.
In fetch_stealth it returns rows with the ephemeral key. The beginning sign byte (02
and 03) was remove and have the client test both combinations.
On further reflection after speaking with caedes, it is a bad idea and
reduces anonymity.
We want to lessen the processing burden on clients, so they can use a
smaller prefix (= more data) to remain more anonymous.