### PR TITLE
- fixes a significant off by one bug in the testnet equivalent of

### DIFF
--- a/src/validate_block.cpp
+++ b/src/validate_block.cpp
@@ -247,11 +247,10 @@ uint32_t validate_block::work_required()
         // or we find a block which does not have max_bits (is not special).
         while (true)
         {
-            --previous_height;
             if (previous_height % readjustment_interval == 0)
                break;
 
-            previous_block = fetch_block(previous_height);
+            previous_block = fetch_block(--previous_height);
             if (previous_block.bits != max_work_bits)
                break;
         }


### PR DESCRIPTION
  'GetNextWorkRequired'.  compared to Satoshi code, the way this is
  written, we must do the difficulty adjustment interval twice on the
  same height rather than adjusting the height before the next check
  (which causes a pow bits failure due to an off by one b/c of the
  premature decrement and loop exit)