### PR TITLE
Version2: patch mempool removals on block accept.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ test_libbitcoin_blockchain_test_SOURCES = \
     test/htdb.cpp \
     test/interface.cpp \
     test/main.cpp \
+    test/transaction_pool.cpp \
     test/validate_block.cpp
 
 endif WITH_TESTS

--- a/builds/msvc/vs2013/libbitcoin-blockchain-test/libbitcoin-blockchain-test.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin-blockchain-test/libbitcoin-blockchain-test.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="..\..\..\..\test\htdb.cpp" />
     <ClCompile Include="..\..\..\..\test\interface.cpp" />
     <ClCompile Include="..\..\..\..\test\main.cpp" />
+    <ClCompile Include="..\..\..\..\test\transaction_pool.cpp" />
     <ClCompile Include="..\..\..\..\test\validate_block.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -104,50 +105,6 @@
     <Error Condition="!Exists('..\..\..\..\..\..\nuget\secp256k1_vc120.0.1.0.8\build\native\secp256k1_vc120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\..\nuget\secp256k1_vc120.0.1.0.8\build\native\secp256k1_vc120.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\..\nuget\openssl_no-asm_vc120.1.0.1.800\build\native\openssl_no-asm_vc120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\..\nuget\openssl_no-asm_vc120.1.0.1.800\build\native\openssl_no-asm_vc120.targets'))" />
   </Target>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLEXE|Win32'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDEXE|Win32'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseSEXE|Win32'">
-    <PostBuildEvent />
-    <PostBuildEvent />
-    <PostBuildEvent>
-      <Command>"$(TargetPath)" --log_level=message --run_test=validate_block --show_progress=no --result_code=no --detect_memory_leak=0 --report_level=no --build_info=yes</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugSEXE|Win32'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugDEXE|Win32'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugLEXE|Win32'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLEXE|x64'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDEXE|x64'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseSEXE|x64'">
-    <PostBuildEvent />
-    <PostBuildEvent />
-    <PostBuildEvent>
-      <Command>"$(TargetPath)" --log_level=message --run_test=validate_block --show_progress=no --result_code=no --detect_memory_leak=0 --report_level=no --build_info=yes</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugSEXE|x64'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugDEXE|x64'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugLEXE|x64'">
-    <PostBuildEvent />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ProjectReference Include="..\libbitcoin-blockchain\libbitcoin-blockchain.vcxproj">
       <Project>{868DAB9E-FD33-497F-9468-C9000B3D7801}</Project>

--- a/builds/msvc/vs2013/libbitcoin-blockchain-test/libbitcoin-blockchain-test.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin-blockchain-test/libbitcoin-blockchain-test.vcxproj.filters
@@ -19,6 +19,9 @@
     <ClCompile Include="..\..\..\..\test\validate_block.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\test\transaction_pool.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/include/bitcoin/blockchain/transaction_pool.hpp
+++ b/include/bitcoin/blockchain/transaction_pool.hpp
@@ -193,7 +193,7 @@ public:
     /// Deprecated, unsafe after startup, use constructor.
     void set_capacity(size_t capacity);
 
-private:
+protected:
     typedef std::error_code code;
     typedef std::function<bool (const transaction_input_type&)>
         input_comparison;

--- a/include/bitcoin/blockchain/transaction_pool.hpp
+++ b/include/bitcoin/blockchain/transaction_pool.hpp
@@ -210,8 +210,8 @@ protected:
         const blockchain::block_list& new_blocks,
         const blockchain::block_list& replaced_blocks);
 
-    void delete_all();
-    void delete_package(const std::error_code& ec);
+    void delete_all(const code& ec);
+    void delete_package(const code& ec);
     void delete_package(const hash_digest& tx_hash, const code& ec);
     void delete_package(const transaction_type& tx, const code& ec);
     void delete_dependencies(const hash_digest& tx_hash, const code& ec);

--- a/include/bitcoin/blockchain/transaction_pool.hpp
+++ b/include/bitcoin/blockchain/transaction_pool.hpp
@@ -210,6 +210,7 @@ protected:
         const blockchain::block_list& new_blocks,
         const blockchain::block_list& replaced_blocks);
 
+    void add(const transaction_type& tx, confirm_handler handler);
     void delete_all(const code& ec);
     void delete_package(const code& ec);
     void delete_package(const hash_digest& tx_hash, const code& ec);

--- a/include/bitcoin/blockchain/transaction_pool.hpp
+++ b/include/bitcoin/blockchain/transaction_pool.hpp
@@ -194,6 +194,11 @@ public:
     void set_capacity(size_t capacity);
 
 private:
+    typedef std::error_code code;
+    typedef std::function<bool (const transaction_input_type&)>
+        input_comparison;
+
+    bool stopped();
     void do_validate(const transaction_type& tx,
         validate_handler handle_validate);
     void validation_complete(const std::error_code& ec, 
@@ -204,10 +209,17 @@ private:
     void reorganize(const std::error_code& ec, size_t fork_point,
         const blockchain::block_list& new_blocks,
         const blockchain::block_list& replaced_blocks);
-    void invalidate_pool();
-    void delete_confirmed(const blockchain::block_list& new_blocks);
-    void try_delete_tx(const hash_digest& hash);
-    bool stopped();
+
+    void delete_all();
+    void delete_package(const std::error_code& ec);
+    void delete_package(const hash_digest& tx_hash, const code& ec);
+    void delete_package(const transaction_type& tx, const code& ec);
+    void delete_dependencies(const hash_digest& tx_hash, const code& ec);
+    void delete_dependencies(const output_point& point, const code& ec);
+    void delete_dependencies(input_comparison is_dependency, const code& ec);
+    void delete_superseded(const blockchain::block_list& blocks);
+    void delete_confirmed_in_blocks(const blockchain::block_list& blocks);
+    void delete_spent_in_blocks(const blockchain::block_list& blocks);
 
     sequencer strand_;
     blockchain& blockchain_;

--- a/src/transaction_pool.cpp
+++ b/src/transaction_pool.cpp
@@ -324,7 +324,7 @@ void transaction_pool::delete_spent_in_blocks(
                     error::double_spend);
 }
 
-// Delete any tx that spends any output of this tx.
+// Delete any tx that spends this output point.
 void transaction_pool::delete_dependencies(const output_point& point,
     const std::error_code& ec)
 {

--- a/src/transaction_pool.cpp
+++ b/src/transaction_pool.cpp
@@ -404,6 +404,7 @@ void transaction_pool::delete_package(const hash_digest& tx_hash,
     const auto it = std::find_if(buffer_.begin(), buffer_.end(), matched);
     if (it != buffer_.end())
     {
+        it->handle_confirm(ec);
         buffer_.erase(it);
         delete_dependencies(tx_hash, ec);
     }

--- a/src/transaction_pool.cpp
+++ b/src/transaction_pool.cpp
@@ -386,7 +386,6 @@ void transaction_pool::delete_package(const std::error_code& ec)
     const auto& oldest = buffer_.front();
     oldest.handle_confirm(ec);
     const auto hash = oldest.hash;
-    buffer_.pop_front();
     delete_package(hash, ec);
 }
 

--- a/test/transaction_pool.cpp
+++ b/test/transaction_pool.cpp
@@ -114,21 +114,29 @@ class transaction_pool_fixture
   : public transaction_pool
 {
 public:
-    transaction_pool_fixture(threadpool& pool, blockchain& chain)
-      : transaction_pool(pool, chain)
+    transaction_pool_fixture(threadpool& pool, blockchain& chain,
+        size_t capacity)
+      : transaction_pool(pool, chain, capacity)
     {
     }
 
+    // Set capcity based on test buffer size.
     transaction_pool_fixture(threadpool& pool, blockchain& chain,
         const pool_buffer& txs)
-      : transaction_pool(pool, chain)
+      : transaction_pool(pool, chain, txs.capacity())
     {
+        // Start by default, fill with our test buffer data.
         stopped_ = false;
         for (const auto& entry: txs)
             buffer_.push_back(entry);
     }
 
     // Test accesors.
+
+    void add(const transaction_type& tx, confirm_handler handler)
+    {
+        transaction_pool::add(tx, handler);
+    }
 
     void delete_all(const std::error_code& ec)
     {
@@ -191,10 +199,10 @@ public:
     }
 };
 
-#define DECLARE_TRANSACTION_POOL(pool) \
+#define DECLARE_TRANSACTION_POOL(pool, capcity) \
     threadpool_fixture memory_pool; \
     blockchain_fixture block_chain; \
-    transaction_pool_fixture pool(memory_pool, block_chain)
+    transaction_pool_fixture pool(memory_pool, block_chain, capcity)
 
 #define DECLARE_TRANSACTION_POOL_TXS(pool, txs) \
     threadpool_fixture memory_pool; \
@@ -219,7 +227,7 @@ BOOST_AUTO_TEST_CASE(transaction_pool__construct1__always__does_not_throw)
 {
     threadpool_fixture pool;
     blockchain_fixture chain;
-    BOOST_REQUIRE_NO_THROW(transaction_pool_fixture(pool, chain));
+    BOOST_REQUIRE_NO_THROW(transaction_pool_fixture(pool, chain, 0));
 }
 
 BOOST_AUTO_TEST_CASE(transaction_pool__construct2__zero__zero)
@@ -231,29 +239,65 @@ BOOST_AUTO_TEST_CASE(transaction_pool__construct2__zero__zero)
 
 BOOST_AUTO_TEST_CASE(transaction_pool__construct2__one__one_destructor_callback)
 {
-    DECLARE_TRANSACTION(1, error::service_stopped);
+    DECLARE_TRANSACTION(0, error::service_stopped);
     pool_buffer buffer(2);
-    buffer.push_back(entry1);
+    buffer.push_back(entry0);
     DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
     BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__add__zero_capacity__empty)
+{
+    DECLARE_TRANSACTION(0, error::service_stopped);
+    pool_buffer transactions(0);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, transactions);
+    mempool.add(tx0, handle_confirm0);
+    BOOST_REQUIRE(mempool.transactions().empty());
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__add__empty__one)
+{
+    DECLARE_TRANSACTION(0, error::service_stopped);
+    pool_buffer transactions(2);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, transactions);
+    mempool.add(tx0, handle_confirm0);
+    BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 1u);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx0_id);
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__add__overflow_two__oldest_two_removed_expected_callbacks)
+{
+    DECLARE_TRANSACTION(0, error::pool_filled);
+    DECLARE_TRANSACTION(1, error::pool_filled);
+    DECLARE_TRANSACTION(2, error::service_stopped);
+    pool_buffer transactions(1);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, transactions);
+    mempool.add(tx0, handle_confirm0);
+    BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 1u);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx0_id);
+    mempool.add(tx1, handle_confirm1);
+    BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 1u);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx1_id);
+    mempool.add(tx2, handle_confirm2);
+    BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 1u);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx2_id);
 }
 
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_all__empty__empty)
 {
     pool_buffer transactions(2);
     DECLARE_TRANSACTION_POOL_TXS(mempool, transactions);
-    BOOST_REQUIRE(mempool.transactions().empty());
     mempool.delete_all(error::unknown);
     BOOST_REQUIRE(mempool.transactions().empty());
 }
 
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_all__two__empty_expected_callbacks)
 {
+    DECLARE_TRANSACTION(0, error::network_unreachable);
     DECLARE_TRANSACTION(1, error::network_unreachable);
-    DECLARE_TRANSACTION(2, error::network_unreachable);
     pool_buffer buffer(2);
+    buffer.push_back(entry0);
     buffer.push_back(entry1);
-    buffer.push_back(entry2);
     DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
     BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 2u);
     mempool.delete_all(error::network_unreachable);
@@ -262,47 +306,81 @@ BOOST_AUTO_TEST_CASE(transaction_pool__delete_all__two__empty_expected_callbacks
 
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_all__stopped_two__empty_expected_callbacks)
 {
+    DECLARE_TRANSACTION(0, error::address_blocked);
     DECLARE_TRANSACTION(1, error::address_blocked);
-    DECLARE_TRANSACTION(2, error::address_blocked);
     pool_buffer buffer(2);
+    buffer.push_back(entry0);
     buffer.push_back(entry1);
-    buffer.push_back(entry2);
     DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
     mempool.stopped(true);
     mempool.delete_all(error::address_blocked);
     BOOST_REQUIRE(mempool.transactions().empty());
 }
 
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_package1__empty__empty)
+{
+    pool_buffer buffer(5);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
+    mempool.delete_package(error::futuristic_timestamp);
+    BOOST_REQUIRE(mempool.transactions().empty());
+}
+
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_package1__three__oldest_removed_expected_callbacks)
 {
-    DECLARE_TRANSACTION(1, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(0, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(1, error::service_stopped);
     DECLARE_TRANSACTION(2, error::service_stopped);
-    DECLARE_TRANSACTION(3, error::service_stopped);
 
     pool_buffer buffer(5);
+    buffer.push_back(entry0);
     buffer.push_back(entry1);
     buffer.push_back(entry2);
-    buffer.push_back(entry3);
     DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
     mempool.delete_package(error::futuristic_timestamp);
     BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 2u);
 }
 
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_package2__empty__empty)
+{
+    pool_buffer buffer(5);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
+    mempool.delete_package(null_hash, error::futuristic_timestamp);
+    BOOST_REQUIRE(mempool.transactions().empty());
+}
+
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_package2__three__match_removed_expected_callbacks)
 {
-    DECLARE_TRANSACTION(1, error::service_stopped);
-    DECLARE_TRANSACTION(2, error::futuristic_timestamp);
-    DECLARE_TRANSACTION(3, error::service_stopped);
+    DECLARE_TRANSACTION(0, error::service_stopped);
+    DECLARE_TRANSACTION(1, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(2, error::service_stopped);
 
     pool_buffer buffer(5);
+    buffer.push_back(entry0);
     buffer.push_back(entry1);
     buffer.push_back(entry2);
-    buffer.push_back(entry3);
     DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
-    mempool.delete_package(hash2, error::futuristic_timestamp);
+    mempool.delete_package(hash1, error::futuristic_timestamp);
     BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 2u);
-    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx1_id);
-    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 1), tx3_id);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx0_id);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 1), tx2_id);
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_package2__no_match__no_change_expected_callbacks)
+{
+    DECLARE_TRANSACTION(0, error::service_stopped);
+    DECLARE_TRANSACTION(1, error::service_stopped);
+    DECLARE_TRANSACTION(2, error::service_stopped);
+
+    pool_buffer buffer(5);
+    buffer.push_back(entry0);
+    buffer.push_back(entry1);
+    buffer.push_back(entry2);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
+    mempool.delete_package(null_hash, error::futuristic_timestamp);
+    BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 3u);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx0_id);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 1), tx1_id);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 2), tx2_id);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/transaction_pool.cpp
+++ b/test/transaction_pool.cpp
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <vector>
+#include <boost/test/unit_test.hpp>
+#include <bitcoin/blockchain.hpp>
+
+using namespace bc;
+using namespace bc::chain;
+
+BOOST_AUTO_TEST_SUITE(transaction_pool)
+
+class threadpool_fixture
+  : public threadpool
+{
+};
+
+class blockchain_fixture
+  : public blockchain
+{
+public:
+    virtual bool start()
+    {
+        return false;
+    }
+
+    virtual bool stop()
+    {
+        return false;
+    }
+
+    virtual void store(const block_type& block,
+        store_block_handler handle_store)
+    {
+    }
+
+    virtual void import(const block_type& import_block,
+        import_block_handler handle_import)
+    {
+    }
+
+    virtual void fetch_block_header(uint64_t height,
+        fetch_handler_block_header handle_fetch)
+    {
+    }
+
+    virtual void fetch_block_header(const hash_digest& hash,
+        fetch_handler_block_header handle_fetch)
+    {
+    }
+
+    virtual void fetch_block_transaction_hashes(const hash_digest& hash,
+        fetch_handler_block_transaction_hashes handle_fetch)
+    {
+    }
+
+    virtual void fetch_block_height(const hash_digest& hash,
+        fetch_handler_block_height handle_fetch)
+    {
+    }
+
+    virtual void fetch_last_height(fetch_handler_last_height handle_fetch)
+    {
+    }
+
+    virtual void fetch_transaction(const hash_digest& hash,
+        fetch_handler_transaction handle_fetch)
+    {
+    }
+
+    virtual void fetch_transaction_index(const hash_digest& hash,
+        fetch_handler_transaction_index handle_fetch)
+    {
+    }
+
+    virtual void fetch_spend(const output_point& outpoint,
+        fetch_handler_spend handle_fetch)
+    {
+    }
+
+    virtual void fetch_history(const payment_address& address,
+        fetch_handler_history handle_fetch, const uint64_t limit=0,
+        const uint64_t from_height=0)
+    {
+    }
+
+    virtual void fetch_stealth(const binary_type& prefix,
+        fetch_handler_stealth handle_fetch, uint64_t from_height=0)
+    {
+    }
+
+    virtual void subscribe_reorganize(reorganize_handler handle_reorganize)
+    {
+    }
+};
+
+class transaction_pool_fixture
+  : public transaction_pool
+{
+public:
+    transaction_pool_fixture(threadpool& pool, blockchain& chain)
+      : transaction_pool(pool, chain)
+    {
+    }
+
+    transaction_pool_fixture(threadpool& pool, blockchain& chain,
+        const pool_buffer& txs)
+      : transaction_pool(pool, chain)
+    {
+        stopped_ = false;
+        for (const auto& entry: txs)
+            buffer_.push_back(entry);
+    }
+
+    // Test accesors.
+
+    void delete_all()
+    {
+        transaction_pool::delete_all();
+    }
+
+    void delete_package(const std::error_code& ec)
+    {
+        transaction_pool::delete_package(ec);
+    }
+
+    void delete_package(const hash_digest& tx_hash, const code& ec)
+    {
+        transaction_pool::delete_package(ec);
+    }
+
+    void delete_package(const transaction_type& tx, const code& ec)
+    {
+        transaction_pool::delete_package(tx, ec);
+    }
+
+    void delete_dependencies(const hash_digest& tx_hash, const code& ec)
+    {
+        transaction_pool::delete_dependencies(tx_hash, ec);
+    }
+
+    void delete_dependencies(const output_point& point, const code& ec)
+    {
+        transaction_pool::delete_dependencies(point, ec);
+    }
+
+    void delete_dependencies(input_comparison is_dependency, const code& ec)
+    {
+        transaction_pool::delete_dependencies(is_dependency, ec);
+    }
+
+    void delete_superseded(const blockchain::block_list& blocks)
+    {
+        transaction_pool::delete_superseded(blocks);
+    }
+
+    void delete_confirmed_in_blocks(const blockchain::block_list& blocks)
+    {
+        transaction_pool::delete_confirmed_in_blocks(blocks);
+    }
+
+    void delete_spent_in_blocks(const blockchain::block_list& blocks)
+    {
+        transaction_pool::delete_spent_in_blocks(blocks);
+    }
+
+    pool_buffer& transactions()
+    {
+        return buffer_;
+    }
+
+    void stopped(bool stop)
+    {
+        stopped_ = stop;
+    }
+};
+
+#define DECLARE_TRANSACTION_POOL(pool) \
+    threadpool_fixture memory_pool; \
+    blockchain_fixture block_chain; \
+    transaction_pool_fixture pool(memory_pool, block_chain)
+
+#define DECLARE_TRANSACTION_POOL_TXS(pool, txs) \
+    threadpool_fixture memory_pool; \
+    blockchain_fixture block_chain; \
+    transaction_pool_fixture pool(memory_pool, block_chain, txs)
+
+BOOST_AUTO_TEST_CASE(transaction_pool__construct1__always__does_not_throw)
+{
+    threadpool_fixture pool;
+    blockchain_fixture chain;
+    BOOST_REQUIRE_NO_THROW(transaction_pool_fixture(pool, chain));
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__construct2__zero__zero)
+{
+    pool_buffer transactions;
+    DECLARE_TRANSACTION_POOL_TXS(mempool, transactions);
+    BOOST_REQUIRE(mempool.transactions().empty());
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__construct2__one__one)
+{
+    pool_buffer transactions(2);
+    transactions.push_back(transaction_entry_info());
+    DECLARE_TRANSACTION_POOL_TXS(mempool, transactions);
+    BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_all__empty__empty)
+{
+    pool_buffer transactions(2);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, transactions);
+    BOOST_REQUIRE(mempool.transactions().empty());
+    mempool.delete_all();
+    BOOST_REQUIRE(mempool.transactions().empty());
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_all__two__expected_handler_calls)
+{
+    const auto handle_confirm = [](const std::error_code& ec)
+    {
+        BOOST_REQUIRE_EQUAL(ec.value(), error::blockchain_reorganized);
+    };
+
+    transaction_type tx;
+    hash_digest hash(null_hash);
+    transaction_entry_info entry1{ hash, tx, handle_confirm };
+    transaction_entry_info entry2{ hash, tx, handle_confirm };
+
+    pool_buffer transactions(2);
+    transactions.push_back(entry1);
+    transactions.push_back(entry2);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, transactions);
+    BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 2u);
+    mempool.delete_all();
+    BOOST_REQUIRE(mempool.transactions().empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/transaction_pool.cpp
+++ b/test/transaction_pool.cpp
@@ -378,9 +378,23 @@ BOOST_AUTO_TEST_CASE(transaction_pool__delete_package1__stopped__unchanged_expec
     BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 1u);
 }
 
-BOOST_AUTO_TEST_CASE(transaction_pool__delete_package1__dependency__deletes_dependency)
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_package1__dependencies__deletes_self_and_dependencies)
 {
-    // TODO:
+    DECLARE_TRANSACTION(0, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(1, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(2, error::futuristic_timestamp);
+    ADD_INPUT_TO_TX_NUMBER(1, hash0, 42);
+    ADD_INPUT_TO_TX_NUMBER(2, hash1, 24);
+    pool_buffer buffer(5);
+    buffer.push_back(entry0);
+    buffer.push_back(entry1);
+    buffer.push_back(entry2);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
+    mempool.delete_package(error::futuristic_timestamp);
+    BOOST_REQUIRE(mempool.transactions().empty());
+    REQUIRE_CALLBACK(0, error::futuristic_timestamp);
+    REQUIRE_CALLBACK(1, error::futuristic_timestamp);
+    REQUIRE_CALLBACK(2, error::futuristic_timestamp);
 }
 
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_package2__empty__empty)
@@ -436,9 +450,23 @@ BOOST_AUTO_TEST_CASE(transaction_pool__delete_package2__stopped__unchanged_expec
     BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 1u);
 }
 
-BOOST_AUTO_TEST_CASE(transaction_pool__delete_package2__dependency__deletes_dependency)
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_package2__dependencies__deletes_self_and_dependencies)
 {
-    // TODO:
+    DECLARE_TRANSACTION(0, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(1, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(2, error::futuristic_timestamp);
+    ADD_INPUT_TO_TX_NUMBER(1, hash0, 42);
+    ADD_INPUT_TO_TX_NUMBER(2, hash1, 24);
+    pool_buffer buffer(5);
+    buffer.push_back(entry0);
+    buffer.push_back(entry1);
+    buffer.push_back(entry2);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
+    mempool.delete_package(hash0, error::futuristic_timestamp);
+    BOOST_REQUIRE(mempool.transactions().empty());
+    REQUIRE_CALLBACK(0, error::futuristic_timestamp);
+    REQUIRE_CALLBACK(1, error::futuristic_timestamp);
+    REQUIRE_CALLBACK(2, error::futuristic_timestamp);
 }
 
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_package3__empty__empty)
@@ -496,9 +524,23 @@ BOOST_AUTO_TEST_CASE(transaction_pool__delete_package3__stopped__unchanged_expec
     BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 1u);
 }
 
-BOOST_AUTO_TEST_CASE(transaction_pool__delete_package3__dependency__deletes_dependency)
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_package3__dependencies__deletes_self_and_dependencies)
 {
-    // TODO:
+    DECLARE_TRANSACTION(0, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(1, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(2, error::futuristic_timestamp);
+    ADD_INPUT_TO_TX_NUMBER(1, hash0, 42);
+    ADD_INPUT_TO_TX_NUMBER(2, hash1, 24);
+    pool_buffer buffer(5);
+    buffer.push_back(entry0);
+    buffer.push_back(entry1);
+    buffer.push_back(entry2);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
+    mempool.delete_package(tx0, error::futuristic_timestamp);
+    BOOST_REQUIRE(mempool.transactions().empty());
+    REQUIRE_CALLBACK(0, error::futuristic_timestamp);
+    REQUIRE_CALLBACK(1, error::futuristic_timestamp);
+    REQUIRE_CALLBACK(2, error::futuristic_timestamp);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -507,6 +549,14 @@ BOOST_AUTO_TEST_SUITE(transaction_pool__delete_dependencies)
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_dependencies1__todo__todo)
 {
     // TODO:
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_dependencies2__empty__empty)
+{
+    pool_buffer buffer(0);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
+    mempool.delete_dependencies(null_hash, error::unknown);
+    BOOST_REQUIRE(mempool.transactions().empty());
 }
 
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_dependencies2__forward_full_chain__head_remains)
@@ -545,6 +595,44 @@ BOOST_AUTO_TEST_CASE(transaction_pool__delete_dependencies2__reverse_full_chain_
     BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx2_id);
     REQUIRE_CALLBACK(0, error::futuristic_timestamp);
     REQUIRE_CALLBACK(1, error::futuristic_timestamp);
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_dependencies2__partial_chain__expected)
+{
+    DECLARE_TRANSACTION(0, error::service_stopped);
+    DECLARE_TRANSACTION(1, error::futuristic_timestamp);
+    DECLARE_TRANSACTION(2, error::service_stopped);
+    ADD_INPUT_TO_TX_NUMBER(1, hash2, 24);
+    pool_buffer buffer(5);
+    buffer.push_back(entry0);
+    buffer.push_back(entry1);
+    buffer.push_back(entry2);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
+    mempool.delete_dependencies(hash2, error::futuristic_timestamp);
+    BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 2u);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx0_id);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 1), tx2_id);
+    REQUIRE_CALLBACK(1, error::futuristic_timestamp);
+}
+
+BOOST_AUTO_TEST_CASE(transaction_pool__delete_dependencies2__stopped_full_chain__unchanged)
+{
+    DECLARE_TRANSACTION(0, error::service_stopped);
+    DECLARE_TRANSACTION(1, error::service_stopped);
+    DECLARE_TRANSACTION(2, error::service_stopped);
+    ADD_INPUT_TO_TX_NUMBER(1, hash0, 42);
+    ADD_INPUT_TO_TX_NUMBER(2, hash1, 24);
+    pool_buffer buffer(5);
+    buffer.push_back(entry0);
+    buffer.push_back(entry1);
+    buffer.push_back(entry2);
+    DECLARE_TRANSACTION_POOL_TXS(mempool, buffer);
+    mempool.stopped(true);
+    mempool.delete_dependencies(hash0, error::unknown);
+    BOOST_REQUIRE_EQUAL(mempool.transactions().size(), 3u);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 0), tx0_id);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 1), tx1_id);
+    BOOST_REQUIRE_EQUAL(TX_ID_AT_POSITION(mempool, 2), tx2_id);
 }
 
 BOOST_AUTO_TEST_CASE(transaction_pool__delete_dependencies3__todo__todo)

--- a/test/transaction_pool.cpp
+++ b/test/transaction_pool.cpp
@@ -24,7 +24,7 @@
 using namespace bc;
 using namespace bc::chain;
 
-BOOST_AUTO_TEST_SUITE(transaction_pool)
+BOOST_AUTO_TEST_SUITE(transaction_pool_tests)
 
 class threadpool_fixture
   : public threadpool


### PR DESCRIPTION
This is complete but not fully tested. The initial fixtures, scaffolding and unit tests for `transaction_pool` are created. The implementation is not optimized, specifically in the implementation of `delete_dependencies`.