### PR TITLE
Implement proper soft fork activation and enforcement logic.

### DIFF
--- a/builds/msvc/vs2013/libbitcoin-blockchain-test/libbitcoin-blockchain-test.props
+++ b/builds/msvc/vs2013/libbitcoin-blockchain-test/libbitcoin-blockchain-test.props
@@ -35,21 +35,18 @@
   </ImportGroup>
 
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
-    <Linkage-openssl>dynamic</Linkage-openssl>
     <Linkage-secp256k1>dynamic</Linkage-secp256k1>
     <Linkage-libbitcoin>dynamic</Linkage-libbitcoin>
     <Linkage-libbitcoin-consensus>dynamic</Linkage-libbitcoin-consensus>
     <Linkage-libbitcoin-blockchain>dynamic</Linkage-libbitcoin-blockchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
-    <Linkage-openssl>static</Linkage-openssl>
     <Linkage-secp256k1>ltcg</Linkage-secp256k1>
     <Linkage-libbitcoin>ltcg</Linkage-libbitcoin>
     <Linkage-libbitcoin-consensus>ltcg</Linkage-libbitcoin-consensus>
     <Linkage-libbitcoin-blockchain>ltcg</Linkage-libbitcoin-blockchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
-    <Linkage-openssl>static</Linkage-openssl>
     <Linkage-secp256k1>static</Linkage-secp256k1>
     <Linkage-libbitcoin>static</Linkage-libbitcoin>
     <Linkage-libbitcoin-consensus>static</Linkage-libbitcoin-consensus>
@@ -59,7 +56,6 @@
   <!-- Messages -->
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Linkage-openssl    : $(Linkage-openssl)" Importance="high"/>
     <Message Text="Linkage-secp256k1  : $(Linkage-secp256k1)" Importance="high"/>
     <Message Text="Linkage-libbitcoin : $(Linkage-libbitcoin)" Importance="high"/>
     <Message Text="Linkage-_consensus : $(Linkage-libbitcoin-consensus)" Importance="high"/>

--- a/builds/msvc/vs2013/libbitcoin-blockchain-tools/libbitcoin-blockchain-tools.props
+++ b/builds/msvc/vs2013/libbitcoin-blockchain-tools/libbitcoin-blockchain-tools.props
@@ -30,21 +30,18 @@
   </ImportGroup>
 
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
-    <Linkage-openssl>dynamic</Linkage-openssl>
     <Linkage-secp256k1>dynamic</Linkage-secp256k1>
     <Linkage-libbitcoin>dynamic</Linkage-libbitcoin>
     <Linkage-libbitcoin-consensus>dynamic</Linkage-libbitcoin-consensus>
     <Linkage-libbitcoin-blockchain>dynamic</Linkage-libbitcoin-blockchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
-    <Linkage-openssl>static</Linkage-openssl>
     <Linkage-secp256k1>ltcg</Linkage-secp256k1>
     <Linkage-libbitcoin>ltcg</Linkage-libbitcoin>
     <Linkage-libbitcoin-consensus>ltcg</Linkage-libbitcoin-consensus>
     <Linkage-libbitcoin-blockchain>ltcg</Linkage-libbitcoin-blockchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
-    <Linkage-openssl>static</Linkage-openssl>
     <Linkage-secp256k1>static</Linkage-secp256k1>
     <Linkage-libbitcoin>static</Linkage-libbitcoin>
     <Linkage-libbitcoin-consensus>static</Linkage-libbitcoin-consensus>
@@ -54,7 +51,6 @@
   <!-- Messages -->
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Linkage-openssl    : $(Linkage-openssl)" Importance="high"/>
     <Message Text="Linkage-secp256k1  : $(Linkage-secp256k1)" Importance="high"/>
     <Message Text="Linkage-libbitcoin : $(Linkage-libbitcoin)" Importance="high"/>
     <Message Text="Linkage-_consensus : $(Linkage-libbitcoin-consensus)" Importance="high"/>

--- a/builds/msvc/vs2013/libbitcoin-blockchain/libbitcoin-blockchain.props
+++ b/builds/msvc/vs2013/libbitcoin-blockchain/libbitcoin-blockchain.props
@@ -29,19 +29,16 @@
   </ImportGroup>
   
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
-    <Linkage-openssl>dynamic</Linkage-openssl>
     <Linkage-secp256k1>dynamic</Linkage-secp256k1>
     <Linkage-libbitcoin>dynamic</Linkage-libbitcoin>
     <Linkage-libbitcoin-consensus>dynamic</Linkage-libbitcoin-consensus>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
-    <Linkage-openssl>static</Linkage-openssl>
     <Linkage-secp256k1>ltcg</Linkage-secp256k1>
     <Linkage-libbitcoin>ltcg</Linkage-libbitcoin>
     <Linkage-libbitcoin-consensus>ltcg</Linkage-libbitcoin-consensus>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
-    <Linkage-openssl>static</Linkage-openssl>
     <Linkage-secp256k1>static</Linkage-secp256k1>
     <Linkage-libbitcoin>static</Linkage-libbitcoin>
     <Linkage-libbitcoin-consensus>static</Linkage-libbitcoin-consensus>
@@ -50,7 +47,6 @@
   <!-- Messages -->
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Linkage-openssl   : $(Linkage-openssl)" Importance="high"/>
     <Message Text="Linkage-secp256k1 : $(Linkage-secp256k1)" Importance="high"/>
     <Message Text="Linkage-libbitcoin: $(Linkage-libbitcoin)" Importance="high"/>
     <Message Text="Linkage-_consensus: $(Linkage-libbitcoin-consensus)" Importance="high"/>

--- a/include/bitcoin/blockchain/implementation/validate_block_impl.hpp
+++ b/include/bitcoin/blockchain/implementation/validate_block_impl.hpp
@@ -21,6 +21,8 @@
 #define LIBBITCOIN_BLOCKCHAIN_IMPL_VALIDATE_BLOCK_H
 
 #include <cstddef>
+#include <cstdint>
+#include <vector>
 #include <bitcoin/bitcoin.hpp>
 #include <bitcoin/blockchain/checkpoint.hpp>
 #include <bitcoin/blockchain/db_interface.hpp>
@@ -47,6 +49,7 @@ protected:
         size_t& previous_height, const hash_digest& tx_hash) const;
     uint64_t median_time_past() const;
     uint32_t previous_block_bits() const;
+    versions preceding_block_versions(size_t maximum) const;
     bool is_output_spent(const output_point& outpoint) const;
     bool is_output_spent(const output_point& previous_output,
         size_t index_in_parent, size_t input_index) const;
@@ -62,6 +65,8 @@ private:
     size_t height_;
     size_t fork_index_;
     size_t orphan_index_;
+    uint32_t activations_;
+    uint32_t minimum_version_;
     const block_detail_list& orphan_chain_;
 };
 

--- a/include/bitcoin/blockchain/validate_block.hpp
+++ b/include/bitcoin/blockchain/validate_block.hpp
@@ -38,7 +38,11 @@ public:
     std::error_code accept_block() const;
     std::error_code connect_block() const;
 
+    /// Required to call before calling accept_block or connect_block.
+    void initialize_context();
+
 protected:
+    typedef std::vector<uint8_t> versions;
     typedef std::function<bool()> stopped_callback;
 
     validate_block(size_t height, const block_type& block,
@@ -54,6 +58,7 @@ protected:
         size_t index_in_parent, size_t input_index) const = 0;
     virtual uint64_t median_time_past() const = 0;
     virtual uint32_t previous_block_bits() const = 0;
+    virtual versions preceding_block_versions(size_t count) const = 0;
     virtual bool transaction_exists(const hash_digest& tx_hash) const = 0;
 
     // These have default implementations that can be overriden.
@@ -67,6 +72,8 @@ protected:
     // These are protected virtual for testability.
     virtual boost::posix_time::ptime current_time() const;
     virtual bool stopped() const;
+    virtual bool is_valid_version() const;
+    virtual bool is_active(script_context flag) const;
     virtual bool is_spent_duplicate(const transaction_type& tx) const;
     virtual bool is_valid_time_stamp(uint32_t timestamp) const;
     virtual uint32_t work_required() const;
@@ -80,6 +87,8 @@ protected:
 
 private:
     const size_t height_;
+    uint32_t activations_;
+    uint32_t minimum_version_;
     const block_type& current_block_;
     const config::checkpoint::list& checkpoints_;
     const stopped_callback stop_callback_;

--- a/include/bitcoin/blockchain/validate_transaction.hpp
+++ b/include/bitcoin/blockchain/validate_transaction.hpp
@@ -46,15 +46,14 @@ public:
         const pool_buffer& pool, sequencer& strand);
     void start(validate_handler handle_validate);
 
+    static bool check_consensus(const script_type& prevout_script,
+        const transaction_type& current_tx, size_t input_index, uint32_t flags);
     static std::error_code check_transaction(const transaction_type& tx);
     static bool connect_input(const transaction_type& tx, size_t current_input,
         const transaction_type& previous_tx, size_t parent_height,
         size_t last_block_height, uint64_t& value_in, uint32_t flags);
     static bool tally_fees(const transaction_type& tx, uint64_t value_in,
         uint64_t& fees);
-    static bool validate_consensus(const script_type& prevout_script,
-        const transaction_type& current_tx, size_t input_index,
-        const block_header_type& header, const size_t height);
 
 private:
     std::error_code basic_checks() const;

--- a/src/implementation/organizer_impl.cpp
+++ b/src/implementation/organizer_impl.cpp
@@ -70,13 +70,15 @@ std::error_code organizer_impl::verify(size_t fork_point,
         return stopped();
     };
 
-    const validate_block_impl validate(interface_, fork_point, orphan_chain,
+    validate_block_impl validate(interface_, fork_point, orphan_chain,
         orphan_index, height, current_block, checkpoints_, callback);
 
     // Checks that are independent of the chain.
     auto ec = validate.check_block();
     if (ec)
         return ec;
+
+    validate.initialize_context();
 
     // Checks that are dependent on height and preceding blocks.
     ec = validate.accept_block();

--- a/src/implementation/validate_block_impl.cpp
+++ b/src/implementation/validate_block_impl.cpp
@@ -57,8 +57,28 @@ block_header_type validate_block_impl::fetch_block(size_t fetch_height) const
 
 uint32_t validate_block_impl::previous_block_bits() const
 {
-    // Read block d - 1 and return bits
+    // Read block (d - 1) and return bits
     return fetch_block(height_ - 1).bits;
+}
+
+validate_block::versions validate_block_impl::preceding_block_versions(
+    size_t maximum) const
+{
+    // 1000 previous versions maximum  sample.
+    // 950 previous versions minimum required for enforcement.
+    // 750 previous versions minimum required for activation.
+    const auto size = std::min(maximum, height_);
+
+    // Read block (d - 1) through (d - 1000) and return version vector.
+    versions result;
+    for (size_t index = 0; index < size; ++index)
+    {
+        const auto version = fetch_block(height_ - index - 1).version;
+        BITCOIN_ASSERT_MSG(version <= max_uint8, "insufficient version domain");
+        result.push_back(static_cast<uint8_t>(version));
+    }
+
+    return result;
 }
 
 uint64_t validate_block_impl::actual_timespan(size_t interval) const

--- a/test/validate_block.cpp
+++ b/test/validate_block.cpp
@@ -30,7 +30,7 @@ class validate_block_fixture
 {
 public:
     validate_block_fixture()
-        : validate_block(0, block_type(), config::checkpoint::list())
+      : validate_block(0, block_type(), config::checkpoint::list())
     {
     }
 
@@ -45,6 +45,11 @@ public:
     uint32_t previous_block_bits() const
     {
         return 0;
+    }
+
+    versions preceding_block_versions(size_t count) const
+    {
+        return versions();
     }
 
     uint64_t actual_timespan(size_t interval) const


### PR DESCRIPTION
Libbitcoin has previously relied on hardcoded heights (for testnet and mainnet) to determine consensus softfork activation and enforcement. These have been incomplete and not fully-constraining validation in the activation ranges. This is more problematic and complex in the midst of a soft fork than the full/proper implementation. These are also potentially invalidated in the case of a deep reorg. This work will activate according to the various BIP specifications, currently BIP16/30/34/66/65.