### PR TITLE
Missing do_fetch invocation in blockchain_impl

### DIFF
--- a/src/implementation/blockchain_impl.cpp
+++ b/src/implementation/blockchain_impl.cpp
@@ -357,6 +357,7 @@ void blockchain_impl::fetch_block_transaction_hashes(
         return finish_fetch(slock, handle_fetch,
             error::success, hashes);
     };
+    fetch_parallel(do_fetch);
 }
 
 void blockchain_impl::fetch_block_height(const hash_digest& hash,


### PR DESCRIPTION
`fetch_block_transaction_hashes` is not calling it's to_fetch function.  This PR calls it with fetch_parallel.