### PR TITLE
Don't stop counting work until existing work is overcome.

### DIFF
--- a/include/bitcoin/blockchain/interface/block_chain.hpp
+++ b/include/bitcoin/blockchain/interface/block_chain.hpp
@@ -71,7 +71,7 @@ public:
     bool get_block_hash(hash_digest& out_hash, size_t height) const;
 
     /// Get the work of the branch starting at the given height.
-    bool get_branch_work(uint256_t& out_work, const uint256_t& maximum,
+    bool get_branch_work(uint256_t& out_work, const uint256_t& overcome,
         size_t height) const;
 
     /// Get the header of the block at the given height.

--- a/include/bitcoin/blockchain/interface/fast_chain.hpp
+++ b/include/bitcoin/blockchain/interface/fast_chain.hpp
@@ -53,7 +53,7 @@ public:
 
     /// Get the work of the branch starting at the given height.
     virtual bool get_branch_work(uint256_t& out_work,
-        const uint256_t& maximum, size_t from_height) const = 0;
+        const uint256_t& overcome, size_t from_height) const = 0;
 
     /// Get the header of the block at the given height.
     virtual bool get_header(chain::header& out_header,

--- a/src/interface/block_chain.cpp
+++ b/src/interface/block_chain.cpp
@@ -91,14 +91,14 @@ bool block_chain::get_block_hash(hash_digest& out_hash, size_t height) const
 }
 
 bool block_chain::get_branch_work(uint256_t& out_work,
-    const uint256_t& maximum, size_t from_height) const
+    const uint256_t& overcome, size_t from_height) const
 {
     size_t top;
     if (!database_.blocks().top(top))
         return false;
 
     out_work = 0;
-    for (auto height = from_height; height <= top && out_work < maximum;
+    for (auto height = from_height; height <= top && out_work <= overcome;
         ++height)
     {
         const auto result = database_.blocks().get(height);

--- a/src/pools/block_organizer.cpp
+++ b/src/pools/block_organizer.cpp
@@ -226,20 +226,20 @@ void block_organizer::handle_connect(const code& ec, branch::ptr branch,
     top_header.median_time_past = top_block.state->median_time_past();
     top_header.height = branch->top_height();
 
-    uint256_t threshold;
-    const auto work = branch->work();
+    uint256_t old_work;
+    const auto new_work = branch->work();
     const auto first_height = branch->height() + 1u;
     top_block.start_notify = asio::steady_clock::now();
 
     // The chain query will stop if it reaches work level.
-    if (!fast_chain_.get_branch_work(threshold, work, first_height))
+    if (!fast_chain_.get_branch_work(old_work, new_work, first_height))
     {
         handler(error::operation_failed);
         return;
     }
 
     // TODO: consider relay of pooled blocks by modifying subscriber semantics.
-    if (work <= threshold)
+    if (new_work <= old_work)
     {
         if (!top_block.simulate)
             block_pool_.add(branch->top());


### PR DESCRIPTION
This is not a consensus failure but in a narrow circumstance it can delay confirmation of a block until another block builds on it.