### PR TITLE
Revert "propagate new bc::settings class"

### DIFF
--- a/include/bitcoin/blockchain/pools/transaction_pool.hpp
+++ b/include/bitcoin/blockchain/pools/transaction_pool.hpp
@@ -42,8 +42,7 @@ public:
     typedef safe_chain::merkle_block_fetch_handler merkle_block_fetch_handler;
     typedef double priority;
 
-    transaction_pool(const settings& settings,
-        const bc::settings& bitcoin_settings);
+    transaction_pool(const settings& settings);
 
     /// The tx exists in the pool.
     bool exists(transaction_const_ptr tx) const;
@@ -82,7 +81,6 @@ private:
     void update_template(priority_iterator max_pool_change);
 
 private:
-    const bc::settings& bitcoin_settings_;
     transaction_pool_state state_;
 };
 

--- a/include/bitcoin/blockchain/populate/populate_header.hpp
+++ b/include/bitcoin/blockchain/populate/populate_header.hpp
@@ -33,16 +33,13 @@ class BCB_API populate_header
   : public populate_base
 {
 public:
-    populate_header(dispatcher& dispatch, const fast_chain& chain,
-        const bc::settings& bitcoin_settings);
+    populate_header(dispatcher& dispatch, const fast_chain& chain);
 
     /// Populate validation state for the top indexed block.
     void populate(header_branch::ptr branch, result_handler&& handler) const;
 
 private:
     bool set_branch_state(header_branch::ptr branch) const;
-
-    const bc::settings& bitcoin_settings_;
 };
 
 } // namespace blockchain

--- a/include/bitcoin/blockchain/validate/validate_header.hpp
+++ b/include/bitcoin/blockchain/validate/validate_header.hpp
@@ -55,6 +55,7 @@ private:
     std::atomic<bool> stopped_;
     const bool retarget_;
     populate_header header_populator_;
+    const bc::settings& bitcoin_settings_;
 };
 
 } // namespace blockchain

--- a/src/interface/block_chain.cpp
+++ b/src/interface/block_chain.cpp
@@ -44,7 +44,7 @@ block_chain::block_chain(threadpool& pool,
     const blockchain::settings& settings,
     const database::settings& database_settings,
     const bc::settings& bitcoin_settings)
-  : database_(database_settings, bitcoin_settings),
+  : database_(database_settings),
     stopped_(true),
     fork_point_({ null_hash, 0 }),
     settings_(settings),
@@ -57,7 +57,7 @@ block_chain::block_chain(threadpool& pool,
 
     // Metadata pools.
     header_pool_(settings.reorganization_limit),
-    transaction_pool_(settings, bitcoin_settings),
+    transaction_pool_(settings),
 
     // Create dispatchers for priority and non-priority operations.
     priority_pool_(thread_ceiling(settings.cores), priority(settings.priority)),
@@ -67,7 +67,8 @@ block_chain::block_chain(threadpool& pool,
     // Organizers use priority dispatch and/or non-priority thread pool.
     block_organizer_(validation_mutex_, priority_, pool, *this, settings,
         bitcoin_settings),
-    header_organizer_(validation_mutex_, priority_, pool, *this, header_pool_, settings, bitcoin_settings),
+    header_organizer_(validation_mutex_, priority_, pool, *this, header_pool_,
+        settings, bitcoin_settings),
     transaction_organizer_(validation_mutex_, priority_, pool, *this, transaction_pool_, settings),
 
     // Subscriber thread pools are only used for unsubscribe, otherwise invoke.

--- a/src/pools/transaction_pool.cpp
+++ b/src/pools/transaction_pool.cpp
@@ -41,9 +41,7 @@ namespace blockchain {
 
 transaction_pool::priority anchor_priority = 0.0;
 
-transaction_pool::transaction_pool(const settings&,
-    const bc::settings& bitcoin_settings)
-  : bitcoin_settings_(bitcoin_settings)
+transaction_pool::transaction_pool(const settings& )
   ////: reject_conflicts_(settings.reject_conflicts),
   ////  minimum_fee_(settings.minimum_fee_satoshis)
 {
@@ -64,8 +62,7 @@ void transaction_pool::filter(get_data_ptr /*message*/) const
 void transaction_pool::fetch_template(merkle_block_fetch_handler handler) const
 {
     const size_t height = max_size_t;
-    const auto block = std::make_shared<message::merkle_block>(
-        bitcoin_settings_);
+    const auto block = std::make_shared<message::merkle_block>();
     handler(error::success, block, height);
 }
 

--- a/src/populate/populate_chain_state.cpp
+++ b/src/populate/populate_chain_state.cpp
@@ -204,8 +204,8 @@ bool populate_chain_state::populate_all(chain_state::data& data,
 // Populate chain state for the top block|header.
 chain_state::ptr populate_chain_state::populate(bool candidate) const
 {
+    header header;
     size_t header_height;
-    header header(bitcoin_settings_);
 
     return fast_chain_.get_top(header, header_height, candidate) ?
         populate(header, header_height, candidate) : nullptr;
@@ -215,7 +215,7 @@ chain_state::ptr populate_chain_state::populate(bool candidate) const
 chain_state::ptr populate_chain_state::populate(size_t header_height,
     bool candidate) const
 {
-    header header(bitcoin_settings_);
+    header header;
 
     return fast_chain_.get_header(header, header_height, candidate) ?
         populate(header, header_height, candidate) : nullptr;

--- a/src/populate/populate_header.cpp
+++ b/src/populate/populate_header.cpp
@@ -30,10 +30,8 @@ using namespace bc::machine;
 
 #define NAME "populate_header"
 
-populate_header::populate_header(dispatcher& dispatch, const fast_chain& chain,
-    const bc::settings& bitcoin_settings)
-  : populate_base(dispatch, chain),
-    bitcoin_settings_(bitcoin_settings)
+populate_header::populate_header(dispatcher& dispatch, const fast_chain& chain)
+  : populate_base(dispatch, chain)
 {
 }
 
@@ -94,7 +92,7 @@ bool populate_header::set_branch_state(header_branch::ptr branch) const
     }
 
     size_t fork_height;
-    chain::header fork_header(bitcoin_settings_);
+    chain::header fork_header;
     const auto fork_hash = branch->hash();
 
     // The grounding candidate may not be valid, but eventually is handled.

--- a/src/validate/validate_block.cpp
+++ b/src/validate/validate_block.cpp
@@ -94,7 +94,11 @@ void validate_block::check(block_const_ptr block, size_t height) const
     else
     {
         // Run context free checks, block is not yet fully validated.
-        metadata.error = block->check(bitcoin_settings_.max_money, retarget_);
+        metadata.error = block->check(bitcoin_settings_.max_money,
+            bitcoin_settings_.timestamp_future_seconds,
+            bitcoin_settings_.retarget_proof_of_work_limit,
+            bitcoin_settings_.no_retarget_proof_of_work_limit,
+            retarget_);
         metadata.validated = false;
     }
 }

--- a/src/validate/validate_header.cpp
+++ b/src/validate/validate_header.cpp
@@ -39,7 +39,8 @@ validate_header::validate_header(dispatcher& dispatch, const fast_chain& chain,
     const settings& settings, const bc::settings& bitcoin_settings)
   : stopped_(true),
     retarget_(settings.retarget),
-    header_populator_(dispatch, chain, bitcoin_settings)
+    header_populator_(dispatch, chain),
+    bitcoin_settings_(bitcoin_settings)
 {
 }
 
@@ -71,7 +72,9 @@ void validate_header::stop()
 code validate_header::check(header_const_ptr header) const
 {
     // Run context free checks, even if under checkpoint or milestone.
-    return header->check(retarget_);
+    return header->check(bitcoin_settings_.timestamp_future_seconds,
+        bitcoin_settings_.retarget_proof_of_work_limit,
+        bitcoin_settings_.no_retarget_proof_of_work_limit, retarget_);
 }
 
 // Accept sequence.

--- a/test/header_branch.cpp
+++ b/test/header_branch.cpp
@@ -28,7 +28,7 @@ using namespace bc::blockchain;
 BOOST_AUTO_TEST_SUITE(header_branch_tests)
 
 #define DECLARE_HEADER(name, number) \
-    const auto name##number = std::make_shared<header>(bc::settings()); \
+    const auto name##number = std::make_shared<header>(); \
     name##number->set_bits(number);
 
 // Access to protected members.

--- a/test/header_entry.cpp
+++ b/test/header_entry.cpp
@@ -33,7 +33,7 @@ static const auto default_header_hash = hash_literal("14508459b221041eab257d2baa
 
 BOOST_AUTO_TEST_CASE(header_entry__construct1__default_header__expected)
 {
-    const auto header = std::make_shared<const message::header>(bc::settings());
+    const auto header = std::make_shared<const message::header>();
     header_entry instance(header, 0);
     BOOST_REQUIRE(instance.header() == header);
     BOOST_REQUIRE(instance.hash() == default_header_hash);
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(header_entry__construct2__default_header_hash__round_trips)
 
 BOOST_AUTO_TEST_CASE(header_entry__parent__hash42__expected)
 {
-    const auto header = std::make_shared<message::header>(bc::settings());
+    const auto header = std::make_shared<message::header>();
     header->set_previous_block_hash(hash42);
     header_entry instance(header, 0);
     BOOST_REQUIRE(instance.parent() == hash42);
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(header_entry__children__default__empty)
 BOOST_AUTO_TEST_CASE(header_entry__add_child__one__single)
 {
     header_entry instance(null_hash);
-    const auto child = std::make_shared<const message::header>(bc::settings());
+    const auto child = std::make_shared<const message::header>();
     instance.add_child(child);
     BOOST_REQUIRE_EQUAL(instance.children().size(), 1u);
     BOOST_REQUIRE(instance.children()[0] == child->hash());
@@ -80,10 +80,10 @@ BOOST_AUTO_TEST_CASE(header_entry__add_child__two__expected_order)
 {
     header_entry instance(null_hash);
 
-    const auto child1 = std::make_shared<const message::header>(bc::settings());
+    const auto child1 = std::make_shared<const message::header>();
     instance.add_child(child1);
 
-    const auto child2 = std::make_shared<message::header>(bc::settings());
+    const auto child2 = std::make_shared<message::header>();
     child2->set_previous_block_hash(hash42);
     instance.add_child(child2);
 
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(header_entry__add_child__two__expected_order)
 
 BOOST_AUTO_TEST_CASE(header_entry__equality__same__true)
 {
-    const auto header = std::make_shared<const message::header>(bc::settings());
+    const auto header = std::make_shared<const message::header>();
     header_entry instance1(header, 0);
     header_entry instance2(header->hash());
     BOOST_REQUIRE(instance1 == instance2);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(header_entry__equality__same__true)
 
 BOOST_AUTO_TEST_CASE(header_entry__equality__different__false)
 {
-    const auto header = std::make_shared<const message::header>(bc::settings());
+    const auto header = std::make_shared<const message::header>();
     header_entry instance1(header, 0);
     header_entry instance2(null_hash);
     BOOST_REQUIRE(!(instance1 == instance2));
@@ -112,14 +112,14 @@ BOOST_AUTO_TEST_CASE(header_entry__equality__different__false)
 
 BOOST_AUTO_TEST_CASE(header_entry__height__default__zero)
 {
-    const auto header = std::make_shared<const message::header>(bc::settings());
+    const auto header = std::make_shared<const message::header>();
     header_entry instance(hash_digest{});
     BOOST_REQUIRE_EQUAL(instance.height(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(header_entry__height__nonzero__expected)
 {
-    const auto header = std::make_shared<const message::header>(bc::settings());
+    const auto header = std::make_shared<const message::header>();
     const auto expected = 42u;
     header_entry instance(header, expected);
     BOOST_REQUIRE_EQUAL(instance.height(), expected);

--- a/test/header_pool.cpp
+++ b/test/header_pool.cpp
@@ -51,7 +51,7 @@ header_const_ptr make_header(uint32_t id, const hash_digest& parent)
 {
     const auto header = std::make_shared<const message::header>(chain::header
     {
-        id, parent, null_hash, 0, 0, 0, bc::settings()
+        id, parent, null_hash, 0, 0, 0
     });
 
     return header;
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(header_pool__add1__one__single)
 BOOST_AUTO_TEST_CASE(header_pool__add1__twice__single)
 {
     header_pool instance(0);
-    const auto header = std::make_shared<const message::header>(bc::settings());
+    const auto header = std::make_shared<const message::header>();
 
     instance.add(header, 0);
     instance.add(header, 0);

--- a/test/transaction_pool.cpp
+++ b/test/transaction_pool.cpp
@@ -32,9 +32,8 @@ BOOST_AUTO_TEST_CASE(transaction_pool__construct__foo__bar)
 
 BOOST_AUTO_TEST_CASE(transaction_pool__add_unconfirmed_transactions__empty_list__noop)
 {
-    bc::settings bitcoin_settings;
-    bc::blockchain::settings blockchain_settings;
-    transaction_pool pool(blockchain_settings, bitcoin_settings);
+    blockchain::settings blockchain_settings;
+    transaction_pool pool(blockchain_settings);
 
     transaction_const_ptr_list txs;
     pool.add_unconfirmed_transactions(txs);

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -34,7 +34,7 @@ chain::block read_block(const std::string& hex)
 {
     data_chunk data;
     BOOST_REQUIRE(decode_base16(data, hex));
-    chain::block result(bc::settings{});
+    chain::block result;
     BOOST_REQUIRE(result.from_data(data));
     return result;
 }
@@ -51,7 +51,7 @@ bool create_database(database::settings& out_database)
 
     error_code ec;
     remove_all(out_database.directory, ec);
-    database::data_base database(out_database, bc::settings{});
+    database::data_base database(out_database);
     return create_directories(out_database.directory, ec) && database.create(
         bc::settings(bc::config::settings::mainnet).genesis_block);
 }

--- a/test/utility.hpp
+++ b/test/utility.hpp
@@ -51,13 +51,11 @@
 #define START_BLOCKCHAIN(name, flush) \
     threadpool pool; \
     database::settings database_settings; \
-    bc::settings bitcoin_settings; \
     database_settings.flush_writes = flush; \
     database_settings.directory = TEST_NAME; \
     BOOST_REQUIRE(test::create_database(database_settings)); \
     blockchain::settings blockchain_settings; \
-    block_chain name(pool, blockchain_settings, database_settings, \
-        bitcoin_settings); \
+    block_chain name(pool, blockchain_settings, database_settings); \
     BOOST_REQUIRE(name.start())
 
 #define NEW_BLOCK(height) \

--- a/tools/initchain/initchain.cpp
+++ b/tools/initchain/initchain.cpp
@@ -63,8 +63,7 @@ int main(int argc, char** argv)
     database::settings settings(config::settings::mainnet);
     const bc::settings bitcoin_settings(config::settings::mainnet);
 
-    if (!data_base(settings, bitcoin_settings).create(
-        bitcoin_settings.genesis_block))
+    if (!data_base(settings).create(bitcoin_settings.genesis_block))
     {
         std::cerr << BS_INITCHAIN_FAIL;
         return -1;


### PR DESCRIPTION
This reverts commit d001f5f7a0e5f014b53e703fc0c3032010676912.

Also, propagate the changes from the main libbitcoin repo.

Reason: https://github.com/libbitcoin/libbitcoin/pull/1013