### PR TITLE
Relay service_stopped to avoid shutdown deadlock

### DIFF
--- a/src/organizers/block_organizer.cpp
+++ b/src/organizers/block_organizer.cpp
@@ -75,8 +75,8 @@ bool block_organizer::start()
 bool block_organizer::stop()
 {
     validator_.stop();
+    downloader_subscriber_->relay(error::service_stopped, null_hash, (size_t)0);
     downloader_subscriber_->stop();
-    downloader_subscriber_->invoke(error::service_stopped, {}, 0);
     stopped_ = true;
     return true;
 }


### PR DESCRIPTION
This seems to be working well, I haven't encountered a shutdown deadlock since implementing this.