### PR TITLE
Stop block_organizer outside of critical section.

### DIFF
--- a/src/interface/block_chain.cpp
+++ b/src/interface/block_chain.cpp
@@ -860,13 +860,15 @@ bool block_chain::stop()
 {
     stopped_ = true;
 
+    // this can't be done in the critical section or block_organizer finishes validation before stop
+    block_organizer_.stop();
+    
     // Critical Section
     ///////////////////////////////////////////////////////////////////////////
     validation_mutex_.lock_high_priority();
 
     // This cannot call organize or stop (lock safe).
     auto result =
-        block_organizer_.stop() &&
         header_organizer_.stop() &&
         transaction_organizer_.stop();
 


### PR DESCRIPTION
This seems to be working for me, without causing any problem with database integrity from discarding pending queued validation work, to signal stop before the validation_mutex_ lock is requested avoids a potentially very long wait for an existing validation sequence to finish and for its mutex lock to be released. Looks like block_organizer::stop() merely sets stop flags, and downloader_subscriber_->stop() does not seem to require validation_mutex_ to be locked so it looks safe to move this here.