### PR TITLE
Add block_chain read and store tests

### DIFF
--- a/include/bitcoin/blockchain/interface/block_chain.hpp
+++ b/include/bitcoin/blockchain/interface/block_chain.hpp
@@ -441,7 +441,7 @@ protected:
     bool stopped() const;
 
     // Notification senders.
-    void notify(system::transaction_const_ptr tx);
+    virtual void notify(system::transaction_const_ptr tx);
     void notify(size_t fork_height,
         system::header_const_ptr_list_const_ptr incoming,
         system::header_const_ptr_list_const_ptr outgoing);
@@ -497,6 +497,12 @@ protected:
     system::code populate_neutrino_filters(
         system::block_const_ptr_list_const_ptr blocks) const;
 
+    // This is protected by mutex.
+    database::data_base database_;
+
+    // Made protected for testing.
+    system::atomic<system::transaction_const_ptr> last_pool_transaction_;
+    virtual void catalog_transaction(system::transaction_const_ptr tx);
 
 private:
     // Properties.
@@ -530,9 +536,6 @@ private:
     bool get_transaction_hashes(system::hash_list& out_hashes,
         const database::block_result& result) const;
 
-    // This is protected by mutex.
-    database::data_base database_;
-
     // These are thread safe.
     std::atomic<bool> stopped_;
 
@@ -540,7 +543,6 @@ private:
     system::atomic<system::uint256_t> candidate_work_;
     system::atomic<system::uint256_t> confirmed_work_;
     system::atomic<system::block_const_ptr> last_confirmed_block_;
-    system::atomic<system::transaction_const_ptr> last_pool_transaction_;
     system::atomic<system::chain::chain_state::ptr> top_candidate_state_;
     system::atomic<system::chain::chain_state::ptr> top_valid_candidate_state_;
     system::atomic<system::chain::chain_state::ptr> next_confirmed_state_;

--- a/include/bitcoin/blockchain/interface/block_chain.hpp
+++ b/include/bitcoin/blockchain/interface/block_chain.hpp
@@ -530,7 +530,6 @@ private:
     void set_neutrino_filter_checkpoints(system::hash_list&& checkpoints);
 
     // Utilities.
-    void catalog_transaction(system::transaction_const_ptr tx);
     bool get_transactions(system::chain::transaction::list& out_transactions,
         const database::block_result& result, bool witness) const;
     bool get_transaction_hashes(system::hash_list& out_hashes,

--- a/src/interface/block_chain.cpp
+++ b/src/interface/block_chain.cpp
@@ -41,8 +41,7 @@ using namespace std::placeholders;
 
 #define NAME "block_chain"
 
-block_chain::block_chain(threadpool& pool,
-    const blockchain::settings& settings,
+block_chain::block_chain(threadpool& pool, const blockchain::settings& settings,
     const database::settings& database_settings,
     const system::settings& bitcoin_settings)
   : database_(database_settings, settings.index_payments, settings.bip158),
@@ -61,7 +60,8 @@ block_chain::block_chain(threadpool& pool,
     transaction_pool_(settings),
 
     // Create dispatcher for priority operations.
-    priority_pool_(thread_ceiling(settings.cores) + 1u, priority(settings.priority)),
+    priority_pool_(
+        thread_ceiling(settings.cores) + 1u, priority(settings.priority)),
     priority_dispatch_(priority_pool_, NAME "_dispatch"),
 
     organize_header_(candidate_mutex_, priority_dispatch_, pool, *this,
@@ -73,8 +73,10 @@ block_chain::block_chain(threadpool& pool,
 
     // Subscriber thread pools are only used for unsubscribe, otherwise invoke.
     block_subscriber_(std::make_shared<block_subscriber>(pool, NAME "_block")),
-    header_subscriber_(std::make_shared<header_subscriber>(pool, NAME "_header")),
-    transaction_subscriber_(std::make_shared<transaction_subscriber>(pool, NAME "_tx"))
+    header_subscriber_(
+        std::make_shared<header_subscriber>(pool, NAME "_header")),
+    transaction_subscriber_(
+        std::make_shared<transaction_subscriber>(pool, NAME "_tx"))
 {
 }
 
@@ -395,7 +397,7 @@ bool block_chain::get_work(uint256_t& out_work, const uint256_t& overcome,
     const auto no_maximum = overcome.is_zero();
 
     for (auto height = top; (height > above_height) &&
-        (no_maximum || out_work <= overcome); --height)
+        (no_maximum || out_work < overcome); --height)
     {
         const auto result = database_.blocks().get(height, candidate);
 

--- a/test/interface/fast_chain.cpp
+++ b/test/interface/fast_chain.cpp
@@ -1052,7 +1052,6 @@ BOOST_AUTO_TEST_CASE(block_chain__store__with_cataloging_tx_metadata_existed__fa
 
     chain::script script0;
     script0.from_string(OUTPUT_SCRIPT0);
-    const auto script_hash0 = sha256_hash(script0.to_data(false));
 
     const chain::input::list inputs
     {

--- a/test/interface/fast_chain.cpp
+++ b/test/interface/fast_chain.cpp
@@ -1,44 +1,1092 @@
-/////**
-//// * Copyright (c) 2011-2019 libbitcoin developers (see AUTHORS)
-//// *
-//// * This file is part of libbitcoin.
-//// *
-//// * This program is free software: you can redistribute it and/or modify
-//// * it under the terms of the GNU Affero General Public License as published by
-//// * the Free Software Foundation, either version 3 of the License, or
-//// * (at your option) any later version.
-//// *
-//// * This program is distributed in the hope that it will be useful,
-//// * but WITHOUT ANY WARRANTY; without even the implied warranty of
-//// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//// * GNU Affero General Public License for more details.
-//// *
-//// * You should have received a copy of the GNU Affero General Public License
-//// * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-//// */
-////#include <boost/test/unit_test.hpp>
-////
-////#include <bitcoin/blockchain.hpp>
-////#include "utility.hpp"
-////
-////using namespace bc;
-////using namespace bc::blockchain;
-////using namespace bc::database;
-////
-////#define TEST_SET_NAME \
-////    "fast_chain_tests"
-////
-////class fast_chain_setup_fixture
-////{
-////public:
-////    fast_chain_setup_fixture()
-////    {
-////        log::initialize();
-////    }
-////};
-////
-////BOOST_FIXTURE_TEST_SUITE(fast_chain_tests, fast_chain_setup_fixture)
-////
+/**
+ * Copyright (c) 2011-2019 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <boost/test/unit_test.hpp>
+
+#include <bitcoin/blockchain.hpp>
+#include "../utility.hpp"
+
+using namespace bc;
+using namespace bc::system;
+using namespace bc::blockchain;
+using namespace bc::database;
+
+#define OUTPUT_SCRIPT0 "dup hash160 [58350574280395ad2c3e2ee20e322073d94e5e40] equalverify checksig"
+
+#define TEST_SET_NAME                           \
+   "fast_chain_tests"
+
+class block_chain_accessor
+  : public block_chain
+{
+public:
+    transaction_const_ptr notified_with;
+    transaction_const_ptr cataloged_with;
+
+    block_chain_accessor(threadpool& pool, const blockchain::settings& settings,
+        const database::settings& database_settings,
+        const system::settings& bitcoin_settings)
+      : block_chain(pool, settings, database_settings, bitcoin_settings)
+    {
+    }
+
+    bool start()
+    {
+        return block_chain::start();
+    }
+
+    database::data_base& database()
+    {
+        return database_;
+    }
+
+    transaction_const_ptr last_pool_transaction() const
+    {
+        return last_pool_transaction_.load();
+    }
+
+    void notify(transaction_const_ptr tx)
+    {
+        notified_with = tx;
+    }
+
+    void catalog_transaction(system::transaction_const_ptr tx)
+    {
+        cataloged_with = tx;
+    }
+
+};
+
+class fast_chain_setup_fixture
+{
+public:
+    fast_chain_setup_fixture()
+    {
+        test::remove_test_directory(TEST_NAME);
+    }
+
+    ~fast_chain_setup_fixture()
+    {
+        test::remove_test_directory(TEST_NAME);
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(fast_chain_tests, fast_chain_setup_fixture)
+
+BOOST_AUTO_TEST_CASE(block_chain__getters__candidate_and_confirmed__success)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+
+    auto& database = instance.database();
+
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+        std::make_shared<const message::header>(block2->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    // Setup ends.
+
+    // Test conditions.
+    config::checkpoint top;
+    chain::header out_header;
+    size_t out_height;
+    BOOST_REQUIRE(instance.get_top(top, true));
+    BOOST_REQUIRE_EQUAL(top.height(), 2u);
+    BOOST_REQUIRE(top.hash() == block2->hash());
+
+    BOOST_REQUIRE(instance.get_top(out_header, out_height, true));
+    BOOST_REQUIRE_EQUAL(out_height, 2u);
+    BOOST_REQUIRE(out_header.hash() == block2->hash());
+
+    BOOST_REQUIRE(instance.get_top(top, false));
+    BOOST_REQUIRE_EQUAL(top.height(), 0u);
+    BOOST_REQUIRE(top.hash() == genesis.hash());
+
+    BOOST_REQUIRE(instance.get_top(out_header, out_height, false));
+    BOOST_REQUIRE_EQUAL(out_height, 0u);
+    BOOST_REQUIRE(out_header.hash() == genesis.hash());
+
+    // Confirm blocks
+    database.invalidate(block1->header(), error::success);
+    database.update(*block1, 1);
+    database.invalidate(block2->header(), error::success);
+    database.update(*block2, 2);
+    const auto incoming_blocks = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block1, block2 });
+    const auto outgoing_blocks = std::make_shared<block_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_blocks, outgoing_blocks), error::success);
+
+    // Test conditions.
+    BOOST_REQUIRE(instance.get_top(top, true));
+    BOOST_REQUIRE_EQUAL(top.height(), 2u);
+    BOOST_REQUIRE(top.hash() == block2->hash());
+
+    BOOST_REQUIRE(instance.get_top(out_header, out_height, true));
+    BOOST_REQUIRE_EQUAL(out_height, 2u);
+    BOOST_REQUIRE(out_header.hash() == block2->hash());
+
+    BOOST_REQUIRE(instance.get_top(top, false));
+    BOOST_REQUIRE_EQUAL(top.height(), 2u);
+    BOOST_REQUIRE(top.hash() == block2->hash());
+
+    BOOST_REQUIRE(instance.get_top(out_header, out_height, false));
+    BOOST_REQUIRE_EQUAL(out_height, 2u);
+    BOOST_REQUIRE(out_header.hash() == block2->hash());
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_header2___present_and_not__true_and_false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+
+    auto& database = instance.database();
+
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    database.invalidate(block1->header(), error::success);
+    database.update(*block1, 1);
+    const auto incoming_blocks = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block1 });
+    const auto outgoing_blocks = std::make_shared<block_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_blocks, outgoing_blocks), error::success);
+
+    // Setup ends.
+
+    // Test conditions.
+    chain::header out_header;
+    size_t out_height;
+    BOOST_REQUIRE(!instance.get_header(out_header, out_height, block2->hash(), true));
+    BOOST_REQUIRE(!instance.get_header(out_header, out_height, block2->hash(), false));
+
+    BOOST_REQUIRE(instance.get_header(out_header, out_height, block1->hash(), true));
+    BOOST_REQUIRE_EQUAL(out_height, 1u);
+    BOOST_REQUIRE(out_header == block1->header());
+
+    BOOST_REQUIRE(instance.get_header(out_header, out_height, block1->hash(), false));
+    BOOST_REQUIRE_EQUAL(out_height, 1u);
+    BOOST_REQUIRE(out_header == block1->header());
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_block_error___present_and_not__true_and_false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+
+    auto& database = instance.database();
+
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    database.invalidate(block1->header(), error::success);
+    database.update(*block1, 1);
+    const auto incoming_blocks = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block1 });
+    const auto outgoing_blocks = std::make_shared<block_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_blocks, outgoing_blocks), error::success);
+
+    // Setup ends.
+
+    // Test conditions.
+    code out_error;
+    BOOST_REQUIRE(!instance.get_block_error(out_error, block2->hash()));
+
+    BOOST_REQUIRE(instance.get_block_error(out_error, block1->hash()));
+    BOOST_REQUIRE_EQUAL(out_error, error::success);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_bits__not_found__false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+   uint32_t out_bits;
+   BOOST_REQUIRE(!instance.get_bits(out_bits, 1, false));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_bits___present_and_not__true_and_false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+
+    auto& database = instance.database();
+
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+        std::make_shared<const message::header>(block2->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    database.invalidate(block1->header(), error::success);
+    database.update(*block1, 1);
+    const auto incoming_blocks = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block1 });
+    const auto outgoing_blocks = std::make_shared<block_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_blocks, outgoing_blocks), error::success);
+
+    // Setup ends.
+
+    // Test conditions.
+    uint32_t out_bits;
+    BOOST_REQUIRE(instance.get_bits(out_bits, 2, true));
+    BOOST_REQUIRE_EQUAL(out_bits, block2->header().bits());
+
+    BOOST_REQUIRE(instance.get_bits(out_bits, 1, false));
+    BOOST_REQUIRE_EQUAL(out_bits, block1->header().bits());
+
+    BOOST_REQUIRE(!instance.get_bits(out_bits, 2, false));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_timestamp__not_found__false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+   uint32_t timestamp;
+   BOOST_REQUIRE(!instance.get_timestamp(timestamp, 1, true));
+   BOOST_REQUIRE(!instance.get_timestamp(timestamp, 1, false));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_timestamp__found__true)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+
+    auto& database = instance.database();
+
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+        std::make_shared<const message::header>(block2->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    uint32_t timestamp;
+    BOOST_REQUIRE(instance.get_timestamp(timestamp, 1, true));
+    BOOST_REQUIRE_EQUAL(timestamp, block1->header().timestamp());
+
+    BOOST_REQUIRE(!instance.get_timestamp(timestamp, 1, false));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_version__not_found__false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+   uint32_t version;
+   BOOST_REQUIRE(!instance.get_version(version, 1, false));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_version__found__true)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+
+    auto& database = instance.database();
+
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+        std::make_shared<const message::header>(block2->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    uint32_t version;
+    BOOST_REQUIRE(instance.get_version(version, 1, true));
+    BOOST_REQUIRE_EQUAL(version, block1->header().version());
+
+    BOOST_REQUIRE(!instance.get_version(version, 1, false));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_version___present_and_not__true_and_false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+
+    auto& database = instance.database();
+
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+        std::make_shared<const message::header>(block2->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    database.invalidate(block1->header(), error::success);
+    database.update(*block1, 1);
+    const auto incoming_blocks = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block1 });
+    const auto outgoing_blocks = std::make_shared<block_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_blocks, outgoing_blocks), error::success);
+
+    // Setup ends.
+
+    // Test conditions.
+    uint32_t out_version;
+    BOOST_REQUIRE(instance.get_version(out_version, 2, true));
+    BOOST_REQUIRE_EQUAL(out_version, block2->header().version());
+
+    BOOST_REQUIRE(instance.get_version(out_version, 1, false));
+    BOOST_REQUIRE_EQUAL(out_version, block1->header().version());
+
+    BOOST_REQUIRE(!instance.get_version(out_version, 2, false));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_branch_work__genesis_confirmed__zero)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+    uint256_t work;
+    uint256_t overcome(max_uint64);
+
+    // This is allowed and just returns zero (standard new single block).
+    BOOST_REQUIRE(instance.get_work(work, overcome, 0, false));
+    BOOST_REQUIRE_EQUAL(work, 0);
+
+    BOOST_REQUIRE(instance.get_work(work, overcome, 0, true));
+    BOOST_REQUIRE_EQUAL(work, 0);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get__work__height_above_top__true)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+    uint256_t work;
+    uint256_t overcome(max_uint64);
+
+    // This is allowed and just returns zero (standard new single block).
+    BOOST_REQUIRE(instance.get_work(work, overcome, 1, false));
+    BOOST_REQUIRE_EQUAL(work, 0);
+}
+
+// NOTE: Old test, doesn't work now. Should be deleted?
+// BOOST_AUTO_TEST_CASE(block_chain__get_branch_work__overcome_zero__true)
+// {
+//     const uint64_t genesis_mainnet_work = 0x0000000100010001;
+//     START_BLOCKCHAIN(instance, false);
+
+//     uint256_t work;
+//     uint256_t overcome(0);
+
+//     // This should not exit early.
+//     BOOST_REQUIRE(instance.get_work(work, overcome, 0, false));
+//     BOOST_REQUIRE_EQUAL(work, genesis_mainnet_work);
+// }
+
+BOOST_AUTO_TEST_CASE(block_chain__get_branch_work__maximum_one__true)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+        std::make_shared<const message::header>(block2->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    uint256_t work;
+    uint256_t overcome(block1->header().proof());
+
+    // This should not exit early due to tying on the first block (order matters).
+    BOOST_REQUIRE(instance.get_work(work, overcome, 0, true));
+    BOOST_REQUIRE_EQUAL(work, block1->header().proof());
+
+    BOOST_REQUIRE(instance.get_work(work, overcome, 0, false));
+    BOOST_REQUIRE_EQUAL(work, 0);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_branch_work__unbounded__true)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+        std::make_shared<const message::header>(block2->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    uint256_t work;
+    uint256_t overcome(max_uint64);
+
+    // This should not exit early but skips the genesis block.
+    BOOST_REQUIRE(instance.get_work(work, overcome, 0, true));
+    BOOST_REQUIRE_EQUAL(work, block1->header().proof() + block2->header().proof());
+
+    BOOST_REQUIRE(instance.get_work(work, overcome, 0, false));
+    BOOST_REQUIRE_EQUAL(work, 0);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_branch_work__confirmed_unbounded__true)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    const auto block1 = NEW_BLOCK(1);
+    const auto block2 = NEW_BLOCK(2);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1->header()),
+        std::make_shared<const message::header>(block2->header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    database.invalidate(block1->header(), error::success);
+    database.update(*block1, 1);
+    database.invalidate(block2->header(), error::success);
+    database.update(*block2, 2);
+    const auto incoming_blocks = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block1, block2 });
+    const auto outgoing_blocks = std::make_shared<block_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_blocks, outgoing_blocks), error::success);
+
+    // Setup ends.
+
+    uint256_t work;
+    uint256_t overcome(max_uint64);
+
+    // This should not exit early but skips the genesis block.
+    BOOST_REQUIRE(instance.get_work(work, overcome, 0, true));
+    BOOST_REQUIRE_EQUAL(work, block1->header().proof() + block2->header().proof());
+
+    BOOST_REQUIRE(instance.get_work(work, overcome, 0, false));
+    BOOST_REQUIRE_EQUAL(work, block1->header().proof() + block2->header().proof());
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_downloadable__not_present__false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+    hash_digest out_hash;
+    BOOST_REQUIRE(!instance.get_downloadable(out_hash, 1));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_downloadable__present_failed_state__false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    const auto block1 = test::read_block(MAINNET_BLOCK1);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    database.invalidate(block1.header(), error::insufficient_fee);
+
+    // Setup ends.
+
+    hash_digest out_hash;
+    BOOST_REQUIRE(!instance.get_downloadable(out_hash, 1));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_downloadable__present_with_transactions__false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    const auto block1 = test::read_block(MAINNET_BLOCK1);
+    const auto block2 = test::read_block(MAINNET_BLOCK2);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    BOOST_REQUIRE_EQUAL(database.blocks().get(0, true).transaction_count(), 1);
+    // Setup ends.
+
+    hash_digest out_hash;
+    BOOST_REQUIRE(!instance.get_downloadable(out_hash, 0));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_downloadable__present_with_transactions__true)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 0);
+    // Setup ends.
+
+    hash_digest out_hash;
+    BOOST_REQUIRE(instance.get_downloadable(out_hash, 1));
+    BOOST_REQUIRE(out_hash == block1.hash());
+}
+
+// get_validatable
+
+BOOST_AUTO_TEST_CASE(block_chain__get_validatable__not_present__false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+    hash_digest out_hash;
+    BOOST_REQUIRE(!instance.get_validatable(out_hash, 1));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_validatable__present_and_failed_state__false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    const auto block1 = test::read_block(MAINNET_BLOCK1);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    database.invalidate(block1.header(), error::insufficient_fee);
+
+    // Setup ends.
+
+    hash_digest out_hash;
+    BOOST_REQUIRE(!instance.get_validatable(out_hash, 1));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_validatable__present_and_valid__false)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    const auto block1 = test::read_block(MAINNET_BLOCK1);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    database.invalidate(block1.header(), error::success);
+
+    // Setup ends.
+
+    hash_digest out_hash;
+    BOOST_REQUIRE(!instance.get_validatable(out_hash, 1));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_validatable__present_without_transactions__true)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 0);
+
+    // Setup ends.
+
+    hash_digest out_hash;
+    BOOST_REQUIRE(!instance.get_validatable(out_hash, 1));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_validatable__present_with_transactions__true)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({ test::random_tx(0), test::random_tx(1) });
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 2);
+
+    // Setup ends.
+
+    hash_digest out_hash;
+    BOOST_REQUIRE(instance.get_validatable(out_hash, 1));
+    BOOST_REQUIRE(out_hash == block1.hash());
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__populate_header__present__success)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({ test::random_tx(0), test::random_tx(1) });
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 2);
+
+    auto& header1 = block1.header();
+    BOOST_REQUIRE(!header1.metadata.candidate);
+
+    // Setup ends.
+
+    instance.populate_header(header1);
+    BOOST_REQUIRE(header1.metadata.candidate);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__populate_block_transaction__present__success)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({ test::random_tx(0), test::random_tx(1) });
+
+    auto transaction1 = block1.transactions().front();
+    BOOST_REQUIRE(!transaction1.metadata.candidate);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 2);
+
+    // Setup ends.
+
+    instance.populate_block_transaction(transaction1, 1, 1);
+    BOOST_REQUIRE(!transaction1.metadata.candidate);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__populate_pool_transaction__present__success)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({ test::random_tx(0), test::random_tx(1) });
+
+    auto transaction1 = block1.transactions().front();
+    BOOST_REQUIRE(!transaction1.metadata.candidate);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 2);
+
+    // Setup ends.
+
+    instance.populate_pool_transaction(transaction1, 1);
+    BOOST_REQUIRE(!transaction1.metadata.candidate);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__populate_block_output__present__success)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({ test::random_tx(0), test::random_tx(1) });
+
+    auto transaction1 = block1.transactions().front();
+    BOOST_REQUIRE(!transaction1.metadata.candidate);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 2);
+
+    // Setup ends.
+
+    const auto& prevout = transaction1.inputs()[0].previous_output();
+    instance.populate_block_output(prevout, 1);
+    BOOST_REQUIRE(!prevout.metadata.candidate);
+    BOOST_REQUIRE(!prevout.metadata.confirmed);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__populate_pool_output__present__success)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({ test::random_tx(0), test::random_tx(1) });
+
+    auto transaction1 = block1.transactions().front();
+    BOOST_REQUIRE(!transaction1.metadata.candidate);
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 2);
+
+    // Setup ends.
+
+    const auto& prevout = transaction1.inputs()[0].previous_output();
+    instance.populate_pool_output(prevout);
+    BOOST_REQUIRE(!prevout.metadata.candidate);
+    BOOST_REQUIRE(!prevout.metadata.confirmed);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_block_state__not_present__missing)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+    // Setup ends.
+
+    uint8_t state = instance.get_block_state(10, true);
+    BOOST_REQUIRE(state == 0);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_block_state__present__success)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({ test::random_tx(0), test::random_tx(1) });
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 2);
+
+    // Setup ends.
+
+    uint8_t state = instance.get_block_state(1, true);
+    BOOST_REQUIRE((state & block_state::candidate) != 0);
+    BOOST_REQUIRE((state & block_state::confirmed) == 0);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_block_state2__not_present__missing)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+    // Setup ends.
+
+    uint8_t state = instance.get_block_state(hash_digest{});
+    BOOST_REQUIRE(state == 0);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_block_state2__present__success)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({ test::random_tx(0), test::random_tx(1) });
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 2);
+
+    // Setup ends.
+
+    uint8_t state = instance.get_block_state(block1.hash());
+    BOOST_REQUIRE((state & block_state::candidate) != 0);
+    BOOST_REQUIRE((state & block_state::confirmed) == 0);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_candidate__not_present__missing)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+    // Setup ends.
+
+    const auto block = instance.get_candidate(10);
+    BOOST_REQUIRE(block == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_candidate__present_without_transactions__missing)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({});
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 0);
+
+    // Setup ends.
+
+    const auto block = instance.get_candidate(1);
+    BOOST_REQUIRE(block == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_candidate__present_with_transactions__success)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    auto& database = instance.database();
+    auto block1 = test::read_block(MAINNET_BLOCK1);
+    block1.set_transactions({ test::random_tx(0), test::random_tx(1) });
+    const auto incoming_headers = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1.header()),
+    });
+    const auto outgoing_headers = std::make_shared<header_const_ptr_list>();
+    BOOST_REQUIRE_EQUAL(database.reorganize({genesis.hash(), 0}, incoming_headers, outgoing_headers), error::success);
+    BOOST_REQUIRE(bc::database::is_candidate(database.blocks().get(1, true).state()));
+    database.update(block1, 1);
+    BOOST_REQUIRE_EQUAL(database.blocks().get(1, true).transaction_count(), 2);
+
+    // Setup ends.
+
+    const auto block = instance.get_candidate(1);
+    BOOST_REQUIRE(block->header().previous_block_hash() == genesis.hash());
+    BOOST_REQUIRE(block->header().merkle_root() != null_hash);
+    BOOST_REQUIRE(block->transactions().size() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__get_header__not_present__missing)
+{
+    START_BLOCKCHAIN(instance, false, true);
+
+    // Setup ends.
+
+    const auto block = instance.get_header(10, true);
+    BOOST_REQUIRE(block == nullptr);
+}
+
+// Writers.
+
+BOOST_AUTO_TEST_CASE(block_chain__store__no_state__failure)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    auto& database = instance.database();
+    auto transaction = std::make_shared<const message::transaction>(test::random_tx(0));
+    BOOST_REQUIRE(!transaction->metadata.state);
+
+    // Setup ends.
+
+    BOOST_REQUIRE_EQUAL(instance.store(transaction), error::operation_failed);
+    BOOST_REQUIRE(!database.transactions().get(transaction->hash()));
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__store__duplicate_transaction__failure)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE_EQUAL(genesis.transactions().size(), 1);
+    auto transaction = std::make_shared<const message::transaction>(genesis.transactions()[0]);
+    transaction->metadata.state = instance.next_confirmed_state();
+
+    // Setup ends.
+
+#ifndef NDEBUG
+    BOOST_REQUIRE_EQUAL(instance.store(transaction), error::duplicate_transaction);
+#else
+    BOOST_REQUIRE(!instance.store(transaction));
+#endif
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__store__without_cataloging__success)
+{
+    START_BLOCKCHAIN(instance, false, false);
+    auto& database = instance.database();
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE_EQUAL(genesis.transactions().size(), 1);
+    auto transaction = std::make_shared<const message::transaction>(test::random_tx(0));
+    const auto initial_state = instance.next_confirmed_state();
+    transaction->metadata.state = initial_state;
+
+    // Setup ends.
+
+    BOOST_REQUIRE_EQUAL(instance.store(transaction), error::success);
+
+    // Transaction is present in database.
+    const auto reloaded = database.transactions().get(transaction->hash());
+    BOOST_REQUIRE(reloaded);
+
+    const auto reloaded_transaction = reloaded.transaction();
+
+    // Transaction metadata says existed.
+    BOOST_REQUIRE(reloaded_transaction.metadata.existed);
+
+    // Last pool transaction is updated.
+    BOOST_REQUIRE(instance.last_pool_transaction() == transaction);
+
+    // invoke() called on transaction subscriber.
+    BOOST_REQUIRE(instance.notified_with == transaction);
+
+    // Transaction is not cataloged.
+    BOOST_REQUIRE(instance.cataloged_with == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__store__with_cataloging_tx_metadata_existed__failure)
+{
+    START_BLOCKCHAIN(instance, false, true);
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE_EQUAL(genesis.transactions().size(), 1);
+
+
+    uint32_t version = 2345u;
+    uint32_t locktime = 0xffffffff;
+
+    chain::script script0;
+    script0.from_string(OUTPUT_SCRIPT0);
+    const auto script_hash0 = sha256_hash(script0.to_data(false));
+
+    const chain::input::list inputs
+    {
+        { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
+    };
+
+    const chain::output::list outputs
+    {
+        { 1200, script0 }
+    };
+
+    chain::transaction tx{ version, locktime, inputs, outputs };
+
+    auto transaction = std::make_shared<const message::transaction>(tx);
+    const auto initial_state = instance.next_confirmed_state();
+    transaction->metadata.state = initial_state;
+
+    // Setup ends.
+
+    BOOST_REQUIRE_EQUAL(instance.store(transaction), error::success);
+
+    // Transaction is cataloged.
+    BOOST_REQUIRE(instance.cataloged_with == transaction);
+}
+
+BOOST_AUTO_TEST_CASE(block_chain__store__with_cataloging_tx_metadata_not_existed__success)
+{
+    // Transaction is present in database.
+    // Transaction metadata state is updated.
+    // Last pool transaction is updated.
+    // Transaction subscriber is invoked.
+    // Transaction is cataloged.
+}
+
 ////BOOST_AUTO_TEST_CASE(block_chain__push__flushed__expected)
 ////{
 ////    START_BLOCKCHAIN(instance, true);
@@ -83,62 +1131,6 @@
 ////    BOOST_REQUIRE(hash == block1->hash());
 ////}
 ////
-////BOOST_AUTO_TEST_CASE(block_chain__get_branch_work__height_above_top__true)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    uint256_t work;
-////    uint256_t overcome(max_uint64);
-////
-////    // This is allowed and just returns zero (standard new single block).
-////    BOOST_REQUIRE(instance.get_work(work, overcome, 1, false));
-////    BOOST_REQUIRE_EQUAL(work, 0);
-////}
-////
-////BOOST_AUTO_TEST_CASE(block_chain__get_branch_work__overcome_zero__true)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    uint256_t work;
-////    uint256_t overcome(0);
-////
-////    // This should not exit early.
-////    BOOST_REQUIRE(instance.get_work(work, overcome, 0, false));
-////    BOOST_REQUIRE_EQUAL(work, genesis_mainnet_work);
-////}
-////
-////
-////BOOST_AUTO_TEST_CASE(block_chain__get_branch_work__maximum_one__true)
-////{
-////    static const uint64_t genesis_mainnet_work = 0x0000000100010001;
-////    START_BLOCKCHAIN(instance, false);
-////
-////    const auto block1 = NEW_BLOCK(1);
-////    BOOST_REQUIRE(instance.push(block1, 1, 0));
-////    uint256_t work;
-////    uint256_t overcome(block1->header().proof());
-////
-////    // This should not exit early due to tying on the first block (order matters).
-////    BOOST_REQUIRE(instance.get_work(work, overcome, 0, false));
-////    BOOST_REQUIRE_EQUAL(work, genesis_mainnet_work + block1->header().proof());
-////}
-////
-////BOOST_AUTO_TEST_CASE(block_chain__get_branch_work__unbounded__true)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    const auto block1 = NEW_BLOCK(1);
-////    const auto block2 = NEW_BLOCK(2);
-////    BOOST_REQUIRE(instance.push(block1, 1, 0));
-////    BOOST_REQUIRE(instance.push(block2, 2, 0));
-////
-////    uint256_t work;
-////    uint256_t overcome(max_uint64);
-////
-////    // This should not exit early but skips the genesis block.
-////    BOOST_REQUIRE(instance.get_work(work, overcome, 1, false));
-////    BOOST_REQUIRE_EQUAL(work, block1->header().proof() + block2->header().proof());
-////}
 ////
 ////////BOOST_AUTO_TEST_CASE(block_chain__get_height__not_found__false)
 ////////{
@@ -160,79 +1152,6 @@
 ////////    BOOST_REQUIRE_EQUAL(height, 1u);
 ////////}
 ////
-////BOOST_AUTO_TEST_CASE(block_chain__get_bits__not_found__false)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    uint32_t bits;
-////    BOOST_REQUIRE(!instance.get_bits(bits, 1, false));
-////}
-////
-////BOOST_AUTO_TEST_CASE(block_chain__get_bits__found__true)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    const auto block1 = NEW_BLOCK(1);
-////    BOOST_REQUIRE(instance.push(block1, 1, 0));
-////
-////    uint32_t bits;
-////    BOOST_REQUIRE(instance.get_bits(bits, 1, false));
-////    BOOST_REQUIRE_EQUAL(bits, block1->header().bits());
-////}
-////
-////BOOST_AUTO_TEST_CASE(block_chain__get_timestamp__not_found__false)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    uint32_t timestamp;
-////    BOOST_REQUIRE(!instance.get_timestamp(timestamp, 1, false));
-////}
-////
-////BOOST_AUTO_TEST_CASE(block_chain__get_timestamp__found__true)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    const auto block1 = NEW_BLOCK(1);
-////    BOOST_REQUIRE(instance.push(block1, 1, 0));
-////
-////    uint32_t timestamp;
-////    BOOST_REQUIRE(instance.get_timestamp(timestamp, 1, false));
-////    BOOST_REQUIRE_EQUAL(timestamp, block1->header().timestamp());
-////}
-////
-////BOOST_AUTO_TEST_CASE(block_chain__get_version__not_found__false)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    uint32_t version;
-////    BOOST_REQUIRE(!instance.get_version(version, 1, false));
-////}
-////
-////BOOST_AUTO_TEST_CASE(block_chain__get_version__found__true)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    const auto block1 = NEW_BLOCK(1);
-////    BOOST_REQUIRE(instance.push(block1, 1, 0));
-////
-////    uint32_t version;
-////    BOOST_REQUIRE(instance.get_version(version, 1, false));
-////    BOOST_REQUIRE_EQUAL(version, block1->header().version());
-////}
-////
-////BOOST_AUTO_TEST_CASE(block_chain__get_top__no_gaps__last_block)
-////{
-////    START_BLOCKCHAIN(instance, false);
-////
-////    const auto block1 = NEW_BLOCK(1);
-////    const auto block2 = NEW_BLOCK(2);
-////    BOOST_REQUIRE(instance.push(block1, 1, 0));
-////    BOOST_REQUIRE(instance.push(block2, 2, 0));
-////
-////    config::checkpoint top;
-////    BOOST_REQUIRE(instance.get_top(top, false));
-////    BOOST_REQUIRE_EQUAL(top.height(), 2u);
-////}
 ////
 ////BOOST_AUTO_TEST_CASE(block_chain__populate_output__not_found__false)
 ////{
@@ -307,5 +1226,4 @@
 ////    BOOST_REQUIRE(!outpoint.metadata.cache.is_valid());
 ////}
 ////
-////BOOST_AUTO_TEST_SUITE_END()
-////
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/interface/fast_chain.cpp
+++ b/test/interface/fast_chain.cpp
@@ -28,8 +28,7 @@ using namespace bc::database;
 
 #define OUTPUT_SCRIPT0 "dup hash160 [58350574280395ad2c3e2ee20e322073d94e5e40] equalverify checksig"
 
-#define TEST_SET_NAME                           \
-   "fast_chain_tests"
+#define TEST_SET_NAME "fast_chain_tests"
 
 class block_chain_accessor
   : public block_chain

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -40,7 +40,7 @@ chain::block read_block(const std::string& hex)
     return result;
 }
 
-bool create_database(database::settings& out_database)
+bool create_database(database::settings& out_database, bool index_payments)
 {
     static const auto mainnet = config::settings::mainnet;
 
@@ -48,12 +48,31 @@ bool create_database(database::settings& out_database)
     out_database.file_growth_rate = 42;
     out_database.block_table_buckets = 42;
     out_database.transaction_table_buckets = 42;
+    out_database.address_table_buckets = 42;
 
     error_code ec;
     remove_all(out_database.directory, ec);
-    database::data_base database(out_database, false, false);
+    database::data_base database(out_database, index_payments, false);
     return create_directories(out_database.directory, ec) &&
         database.create(system::settings(mainnet).genesis_block);
+}
+
+void remove_test_directory(std::string directory)
+{
+    error_code ec;
+    remove_all(directory, ec);
+}
+
+chain::transaction random_tx(size_t fudge)
+{
+    static const auto settings = system::settings(
+        system::config::settings::mainnet);
+    static const chain::block genesis = settings.genesis_block;
+    auto tx = genesis.transactions()[0];
+    tx.inputs()[0].previous_output().set_index(fudge);
+    tx.metadata.link = chain::transaction::validation::unlinked;
+    tx.metadata.existed = false;
+    return tx;
 }
 
 } // namespace test

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -48,7 +48,7 @@ bool create_database(database::settings& out_database, bool index_payments)
     out_database.file_growth_rate = 42;
     out_database.block_table_buckets = 42;
     out_database.transaction_table_buckets = 42;
-    out_database.address_table_buckets = 42;
+    out_database.payment_table_buckets = 42;
 
     error_code ec;
     remove_all(out_database.directory, ec);

--- a/test/utility.hpp
+++ b/test/utility.hpp
@@ -48,14 +48,17 @@
 #define TEST_NAME \
     std::string(boost::unit_test::framework::current_test_case().p_name)
 
-#define START_BLOCKCHAIN(name, flush) \
-    threadpool pool; \
-    database::settings database_settings; \
-    database_settings.flush_writes = flush; \
-    database_settings.directory = TEST_NAME; \
-    BOOST_REQUIRE(test::create_database(database_settings)); \
-    blockchain::settings blockchain_settings; \
-    block_chain name(pool, blockchain_settings, database_settings); \
+#define START_BLOCKCHAIN(name, flush, catalog)                                 \
+    threadpool pool;                                                           \
+    database::settings database_settings;                                      \
+    database_settings.flush_writes = flush;                                    \
+    database_settings.directory = TEST_NAME;                                   \
+    BOOST_REQUIRE(test::create_database(database_settings, catalog));   \
+    blockchain::settings blockchain_settings;                                  \
+    blockchain_settings.index_payments = catalog;                              \
+    bc::system::settings bitcoin_settings;                                     \
+    block_chain_accessor name(                                                 \
+        pool, blockchain_settings, database_settings, bitcoin_settings);       \
     BOOST_REQUIRE(name.start())
 
 #define NEW_BLOCK(height) \
@@ -63,7 +66,9 @@
 
 namespace test {
 
-bc::chain::block read_block(const std::string& hex);
-bool create_database(bc::database::settings& out_database);
+bc::system::chain::block read_block(const std::string& hex);
+bool create_database(bc::database::settings& out_database, bool index_payments);
+void remove_test_directory(std::string name);
+bc::system::chain::transaction random_tx(size_t fudge);
 
 } // namespace test

--- a/test/utility.hpp
+++ b/test/utility.hpp
@@ -48,17 +48,17 @@
 #define TEST_NAME \
     std::string(boost::unit_test::framework::current_test_case().p_name)
 
-#define START_BLOCKCHAIN(name, flush, catalog)                                 \
-    threadpool pool;                                                           \
-    database::settings database_settings;                                      \
-    database_settings.flush_writes = flush;                                    \
-    database_settings.directory = TEST_NAME;                                   \
-    BOOST_REQUIRE(test::create_database(database_settings, catalog));   \
-    blockchain::settings blockchain_settings;                                  \
-    blockchain_settings.index_payments = catalog;                              \
-    bc::system::settings bitcoin_settings;                                     \
-    block_chain_accessor name(                                                 \
-        pool, blockchain_settings, database_settings, bitcoin_settings);       \
+#define START_BLOCKCHAIN(name, flush, catalog) \
+    threadpool pool; \
+    database::settings database_settings; \
+    database_settings.flush_writes = flush; \
+    database_settings.directory = TEST_NAME; \
+    BOOST_REQUIRE(test::create_database(database_settings, catalog)); \
+    blockchain::settings blockchain_settings; \
+    blockchain_settings.index_payments = catalog; \
+    bc::system::settings bitcoin_settings; \
+    block_chain_accessor name( \
+        pool, blockchain_settings, database_settings, bitcoin_settings); \
     BOOST_REQUIRE(name.start())
 
 #define NEW_BLOCK(height) \


### PR DESCRIPTION
- Setup in place for fast_chain get methods

- Add test for get_header by hash

- Add test for fast_chain get_block_error

- Add test for fast_chain::get_bits

- Add tests for fast_chain::get_work

- Add get_work test

- Change <= to < for comparing overcome in block_chain::get_work

- uncomment get_work tests that were fixed earlier

- Add tests for fast_chain::get_downloadable

- Bring back tests for block_chain get_version and get_timestamp

- Add tests for block_chain::get_validatable

- Add tests for fast_chain populate tests

- Add tests for get_block_state

- Add tests for fast_chain::get_candidate

- Add fast_chain::get_header test for missing header

- Fix error in populate_header test

- Add store tests

- Add test for block_chain::store transaction

- Use NDEBUG flag to test transaction store return error

- Add test for store without indexing payments

- Change block_chain test helper to respect catalog flag

- block_chain:: store tests, messing with virtual functions

- In fast_chain::store, use a custom transactions instead of random_tx